### PR TITLE
Feature/movies node script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 .deta
 package-lock.json
-yarn-lock.json
+yarn.lock
 deta

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .deta
 package-lock.json
+yarn-lock.json
 deta

--- a/README.md
+++ b/README.md
@@ -18,3 +18,19 @@ Template :
     "director": " "
 }
 ```
+
+### Install and Run the API locally:
+
+1. Install dependencies:
+`npm install` or `yarn`
+
+2. Run locally:
+`npm run start` or `yarn start`
+
+### Routes
+
+Total number of movies:
+http://localhost:5000
+
+Get a random movie:
+http://localhost:5000/random

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Add your data in double quotes : " ",
 
 template :
  
-{
-
+```
+{  
     "id": ,
     "name": " ",
     "yearReleased": " ",
     "language": " ",
     "director": " "
 }
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Still if you are unable to find info you can write NIL.
 Add your data in double quotes : " ",  
 (don't use " " for numbers)
 
-template :
+Template :
  
 ```
 {  

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # horror-movie-api
-This is a repository to make a data set of the best horror movies to watch
+This is a repository to make a data set of the best horror movies to watch.
 
 
 (if you dont know any of the following spec you can google it or use ctrl + shift + esc > performance
 still if you are unable to find info you can write NIL)
 
-Add you data in double inverted comma : " ",
+Add your data in double quotes : " ",
 (don't use " " for numbers)
 
 template :

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # horror-movie-api
 This is a repository to make a data set of the best horror movies to watch.
+  
+If you dont know any of the following spec you can Google it or use Ctrl + Shift + Esc > Performance
+Still if you are unable to find info you can write NIL.
 
-
-(if you dont know any of the following spec you can google it or use ctrl + shift + esc > performance
-still if you are unable to find info you can write NIL)
-
-Add your data in double quotes : " ",
+Add your data in double quotes : " ",  
 (don't use " " for numbers)
 
 template :

--- a/data.json
+++ b/data.json
@@ -1,4665 +1,4665 @@
 [
-    {
-        "id": 1,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 3,
-        "name": "The Ring",
-        "yearReleased": "2004",
-        "language": "English",
-        "director": "Andy Newsir"
-    },
-    {
-        "id": 4,
-        "name": "Dahmer",
-        "yearReleased": "2002",
-        "language": "English",
-        "director": "David Jacobson"
-    },
-    {
-        "id": 5,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 6,
-        "name": "One Missed Call",
-        "yearReleased": "2008",
-        "language": "English",
-        "director": "Eric Vallete"
-    },
-    {
-        "id": 7,
-        "name": "The Midnigth Club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 8,
-        "name": "Insidious",
-        "yearReleased": "2010",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 9,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "plazo"
-    },
-    {
-        "id": 10,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 11,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "paco plazo"
-    },
-    {
-        "id": 12,
-        "name": " The Omen in Devil Town ",
-        "yearReleased": "1993",
-        "language": "English",
-        "director": "Qumin Lee"
-    },
-    {
-        "id": 13,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 14,
-        "name": " 6 and 1 (In the Mind)",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "Sudhanshu Saria"
-    },
-    {
-        "id": 15,
-        "name": "Faz-me Companhia",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "João Pedro Rodrigues"
-    },
-    {
-        "id": 16,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 17,
-        "name": "Paranormal Activity",
-        "yearReleased": "2007",
-        "language": "English",
-        "director": "Oren Peli"
-    },
-    {
-        "id": 18,
-        "name": "Paranormal Activity 2",
-        "yearReleased": "2010",
-        "language": "English",
-        "director": "Tod Williams"
-    },
-    {
-        "id": 19,
-        "name": "Paranormal Activity 3",
-        "yearReleased": "2011",
-        "language": "English",
-        "director": "Henry joost,Ariel Schulman"
-    },
-    {
-        "id": 20,
-        "name": "Paranormal Activity 4",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "Henry joost,Ariel Schulman"
-    },
-    {
-        "id": 20,
-        "name": "Kanchana",
-        "yearReleased": "2016",
-        "language": "Tamil",
-        "director": "Indian Insan"
-    },
-    {
-        "id": 22,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 23,
-        "name": " Barbarian",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "TZach Cregger"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 20,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 25,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 26,
-        "name": "Videodrome",
-        "yearReleased": "1983",
-        "language": "English",
-        "director": " David Cronenberg"
-    },
-    {
-        "id": 27,
-        "name": " Horror Story",
-        "yearReleased": "2013",
-        "language": "Hindi",
-        "director": "Ayush Raina"
-    },
-    {
-        "id": 28,
-        "name": "The Exorcist",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Andy Newber"
-    },
-    {
-        "id": 29,
-        "name": "The Weird Man",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 30,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 31,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 32,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 33,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 34,
-        "name": "nightmare of the elm street",
-        "yearReleased": "1984",
-        "language": "English",
-        "director": "Wes Craven"
-    },
-    {
-        "id": 35,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {
-        "id": 36,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 37,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "The Unholy",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Evan Spiliotopoulos"
-    },
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 21,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 22,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 23,
-        "name": "nightmare of the elm street",
-        "yearReleased": "1984",
-        "language": "English",
-        "director": "Wes Craven"
-    },
-    {
-        "id": 24,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 26,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "The Unholy",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Evan Spiliotopoulos"
-    },
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 26,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "stree",
-        "yearReleased": "2020",
-        "language": "Hindi",
-        "director": "dev deol"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 24,
-        "name": "Dead Silence",
-        "yearReleased": "2007",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 21,
-        "name": "Mahal",
-        "yearReleased": "1949",
-        "language": "Hindi",
-        "director": "Kamal Amrohi"
-    },
-    {
-        "id": 30,
-        "name": "US",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "Jordan Peele"
-    },
-    {
-        "id": 50,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 21,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 28,
-        "name": "Midsommar",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": " Ari Aster"
-    },
-    {},
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 29,
-        "name": "Orphan",
-        "yearReleased": "2009",
-        "language": "English",
-        "director": "Jaume Collet-Serra"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 22,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {},
-    {
-        "id": 24,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 22,
-        "name": "Arundhati",
-        "yearReleased": "2009",
-        "language": "Telugu",
-        "director": "Kodi Ramakrishna"
-    },
-    {
-        "id": 25,
-        "name": "Nope",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Jordan Peele"
-    },
-    {
-        "id": 32,
-        "name": "Bhool Bhulaiyaa  ",
-        "yearReleased": "2007",
-        "language": "Hindi",
-        "director": "Priyadarshan"
-    },
-    {
-        "id": 32,
-        "name": "stree",
-        "yearReleased": "2019",
-        "language": "Hindi",
-        "director": "Amar Kaushik"
-    },
-    {
-        "id": 27,
-        "name": "sinister",
-        "yearReleased": "2012",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 27,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 28,
-        "name": "Train to Busan",
-        "yearReleased": " 2016",
-        "language": "korean",
-        "director": "Yeon Sang-ho"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 27,
-        "name": "sinister",
-        "yearReleased": "2012",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 27,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 28,
-        "name": "Train to Busan",
-        "yearReleased": " 2016",
-        "language": "korean",
-        "director": "Yeon Sang-ho"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 21,
-        "name": "The Nun",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Corin Hardy"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "shaapit",
-        "yearReleased": "2010",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 21,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "TZach Cregger"
-    },
-    {
-        "id": 20,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 55,
-        "name": "Malignant",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 24,
-        "name": "IT",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Andrés Muschietti"
-    },
-    {
-        "id": 26,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 21,
-        "name": "Anabella",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "John R. Leonetti"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 56,
-        "name": "Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 29,
-        "name": "Hereditary",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Ari Aster"
-    },
-    {
-        "id": 22,
-        "name": "Roohi",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Hardik Mehta"
-    },
-    {
-        "id": 23,
-        "name": "Stree",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Amar Kaushik"
-    },
-    {
-        "id": 26,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 7008,
-        "name": "Handjob Cabin",
-        "yearReleased": "2015",
-        "language": "English",
-        "director": "Bennet Silverman"
-    },
-    {
-        "id": 21,
-        "name": " Chhorii",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Vishal Furia"
-    },
-    {
-        "id": 27,
-        "name": "kanchan",
-        "yearReleased": "2013",
-        "language": "Hindi",
-        "director": "ssr"
-    },
-    {
-        "id": 21,
-        "name": "Host",
-        "yearRealeased": "2020",
-        "language": "English",
-        "director": "Rob Savage"
-    },
-    {
-        "id": 22,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "Corin Hardy"
-    },
-    {
-        "id": 21,
-        "name": "stree",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "BANSALI"
-    },
-    {
-        "id": 21,
-        "name": "The Shining",
-        "yearReleased": "1980",
-        "language": "English",
-        "director": "Stanley Kubrick"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 57,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "English",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Old",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "M. Night Shyamalan"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 20,
-        "name": "Chhorii",
-        "yearReleased": "2021",
-        "language": "hindi",
-        "director": "Vishal Furia"
-    },
-    {
-        "id": 21,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Paco Plaza"
-    },
-    {
-        "id": 21,
-        "name": "6-5=2",
-        "yearReleased": "2014",
-        "language": "HINDI",
-        "director": "Bharat Jain"
-    },
-    {
-        "id": 22,
-        "name": "brahmastra",
-        "yearReleased": "2022",
-        "language": "HINDI",
-        "director": "Ayan Mukerji"
-    },
-    {
-        "id": 21,
-        "name": "IT'S ALIVE! ",
-        "yearReleased": "1974",
-        "language": "English",
-        "director": "Larry Cohen"
-    },
-    {
-        "id": 28,
-        "name": "The Grudge",
-        "yearReleased": "2004",
-        "language": "Japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 21,
-        "name": "Haunted – 3D",
-        "yearReleased": "2011",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 79,
-        "name": "The Ring",
-        "yearReleased": "2003",
-        "language": "English",
-        "director": "Gore Verbinski"
-    },
-    {
-        "id": 22,
-        "name": "The Conjuring 2",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 23,
-        "name": "Resident Evil",
-        "yearReleased": "2002",
-        "language": "English",
-        "director": "Paul W.S. Anderson"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "John boorman"
-    },
-    {
-        "id": 29,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 23,
-        "name": "IT",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Andy Muschietti"
-    },
-    {
-        "id": 24,
-        "name": "Get Out",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Jordan Peele"
-    },
-    {
-        "id": 231,
-        "name": "Halloween Kills",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "David Gordon Green"
-    },
-    {
-        "id": 1,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 2,
-        "name": "Host",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Andy Newber"
-    },
-    {
-        "id": 3,
-        "name": "The Ring",
-        "yearReleased": "2004",
-        "language": "English",
-        "director": "Andy Newsir"
-    },
-    {
-        "id": 4,
-        "name": "Dahmer",
-        "yearReleased": "2002",
-        "language": "English",
-        "director": "David Jacobson"
-    },
-    {
-        "id": 5,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 6,
-        "name": "one missed call",
-        "yearReleased": "2008",
-        "language": "English",
-        "director": "Eric Vallete"
-    },
-    {
-        "id": 7,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 8,
-        "name": "Insidious",
-        "yearReleased": "2010",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 9,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "plazo"
-    },
-    {
-        "id": 10,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 11,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "paco plazo"
-    },
-    {
-        "id": 12,
-        "name": " The Omen in Devil Town ",
-        "yearReleased": "1993",
-        "language": "English",
-        "director": "Qumin Lee"
-    },
-    {
-        "id": 13,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 14,
-        "name": " 6 and 1 (In the Mind)",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "Sudhanshu Saria"
-    },
-    {
-        "id": 15,
-        "name": "Faz-me Companhia",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "João Pedro Rodrigues"
-    },
-    {
-        "id": 16,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 17,
-        "name": "Paranormal Activity",
-        "yearReleased": "2007",
-        "language": "English",
-        "director": "Oren Peli"
-    },
-    {
-        "id": 18,
-        "name": "Paranormal Activity 2",
-        "yearReleased": "2010",
-        "language": "English",
-        "director": "Tod Williams"
-    },
-    {
-        "id": 19,
-        "name": "Paranormal Activity 3",
-        "yearReleased": "2011",
-        "language": "English",
-        "director": "Henry joost,Ariel Schulman"
-    },
-    {
-        "id": 20,
-        "name": "Paranormal Activity 4",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "Henry joost,Ariel Schulman"
-    },
-    {
-        "id": 20,
-        "name": "Kanchana",
-        "yearReleased": "2016",
-        "language": "Tamil",
-        "director": "Indian Insan"
-    },
-    {
-        "id": 22,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 23,
-        "name": " Barbarian",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "TZach Cregger"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 20,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 25,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 26,
-        "name": "Videodrome",
-        "yearReleased": "1983",
-        "language": "English",
-        "director": " David Cronenberg"
-    },
-    {
-        "id": 27,
-        "name": " Horror Story",
-        "yearReleased": "2013",
-        "language": "Hindi",
-        "director": "Ayush Raina"
-    },
-    {
-        "id": 28,
-        "name": "The Exorcist",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Andy Newber"
-    },
-    {
-        "id": 29,
-        "name": "The Weird Man",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 30,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 31,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 32,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 33,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 34,
-        "name": "nightmare of the elm street",
-        "yearReleased": "1984",
-        "language": "English",
-        "director": "Wes Craven"
-    },
-    {
-        "id": 35,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {
-        "id": 36,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 37,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "The Unholy",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Evan Spiliotopoulos"
-    },
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 21,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 22,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 23,
-        "name": "nightmare of the elm street",
-        "yearReleased": "1984",
-        "language": "English",
-        "director": "Wes Craven"
-    },
-    {
-        "id": 24,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 26,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "The Unholy",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Evan Spiliotopoulos"
-    },
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 26,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "stree",
-        "yearReleased": "2020",
-        "language": "Hindi",
-        "director": "dev deol"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 24,
-        "name": "Dead Silence",
-        "yearReleased": "2007",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 21,
-        "name": "Mahal",
-        "yearReleased": "1949",
-        "language": "Hindi",
-        "director": "Kamal Amrohi"
-    },
-    {
-        "id": 30,
-        "name": "US",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "Jordan Peele"
-    },
-    {
-        "id": 50,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 21,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 28,
-        "name": "Midsommar",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": " Ari Aster"
-    },
-    {},
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 29,
-        "name": "Orphan",
-        "yearReleased": "2009",
-        "language": "English",
-        "director": "Jaume Collet-Serra"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 22,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {},
-    {
-        "id": 24,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 22,
-        "name": "Arundhati",
-        "yearReleased": "2009",
-        "language": "Telugu",
-        "director": "Kodi Ramakrishna"
-    },
-    {
-        "id": 25,
-        "name": "Nope",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Jordan Peele"
-    },
-    {
-        "id": 32,
-        "name": "Bhool Bhulaiyaa  ",
-        "yearReleased": "2007",
-        "language": "Hindi",
-        "director": "Priyadarshan"
-    },
-    {
-        "id": 32,
-        "name": "stree",
-        "yearReleased": "2019",
-        "language": "Hindi",
-        "director": "Amar Kaushik"
-    },
-    {
-        "id": 27,
-        "name": "sinister",
-        "yearReleased": "2012",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 27,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 28,
-        "name": "Train to Busan",
-        "yearReleased": " 2016",
-        "language": "korean",
-        "director": "Yeon Sang-ho"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 27,
-        "name": "sinister",
-        "yearReleased": "2012",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 27,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 28,
-        "name": "Train to Busan",
-        "yearReleased": " 2016",
-        "language": "korean",
-        "director": "Yeon Sang-ho"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 21,
-        "name": "The Nun",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Corin Hardy"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "shaapit",
-        "yearReleased": "2010",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 21,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "TZach Cregger"
-    },
-    {
-        "id": 20,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 55,
-        "name": "Malignant",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 24,
-        "name": "IT",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Andrés Muschietti"
-    },
-    {
-        "id": 26,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 21,
-        "name": "Anabella",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "John R. Leonetti"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 56,
-        "name": "Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 29,
-        "name": "Hereditary",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Ari Aster"
-    },
-    {
-        "id": 22,
-        "name": "Roohi",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Hardik Mehta"
-    },
-    {
-        "id": 23,
-        "name": "Stree",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Amar Kaushik"
-    },
-    {
-        "id": 26,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 7008,
-        "name": "Handjob Cabin",
-        "yearReleased": "2015",
-        "language": "English",
-        "director": "Bennet Silverman"
-    },
-    {
-        "id": 21,
-        "name": " Chhorii",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Vishal Furia"
-    },
-    {
-        "id": 27,
-        "name": "kanchan",
-        "yearReleased": "2013",
-        "language": "Hindi",
-        "director": "ssr"
-    },
-    {
-        "id": 21,
-        "name": "Host",
-        "yearRealeased": "2020",
-        "language": "English",
-        "director": "Rob Savage"
-    },
-    {
-        "id": 22,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "Corin Hardy"
-    },
-    {
-        "id": 21,
-        "name": "stree",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "BANSALI"
-    },
-    {
-        "id": 21,
-        "name": "The Shining",
-        "yearReleased": "1980",
-        "language": "English",
-        "director": "Stanley Kubrick"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 57,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "English",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Old",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "M. Night Shyamalan"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 20,
-        "name": "Chhorii",
-        "yearReleased": "2021",
-        "language": "hindi",
-        "director": "Vishal Furia"
-    },
-    {
-        "id": 21,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Paco Plaza"
-    },
-    {
-        "id": 21,
-        "name": "6-5=2",
-        "yearReleased": "2014",
-        "language": "HINDI",
-        "director": "Bharat Jain"
-    },
-    {
-        "id": 22,
-        "name": "brahmastra",
-        "yearReleased": "2022",
-        "language": "HINDI",
-        "director": "Ayan Mukerji"
-    },
-    {
-        "id": 21,
-        "name": "IT'S ALIVE! ",
-        "yearReleased": "1974",
-        "language": "English",
-        "director": "Larry Cohen"
-    },
-    {
-        "id": 28,
-        "name": "The Grudge",
-        "yearReleased": "2004",
-        "language": "Japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 21,
-        "name": "Haunted – 3D",
-        "yearReleased": "2011",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 79,
-        "name": "The Ring",
-        "yearReleased": "2003",
-        "language": "English",
-        "director": "Gore Verbinski"
-    },
-    {
-        "id": 22,
-        "name": "The Conjuring 2",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 23,
-        "name": "Resident Evil",
-        "yearReleased": "2002",
-        "language": "English",
-        "director": "Paul W.S. Anderson"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "John boorman"
-    },
-    {
-        "id": 29,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 23,
-        "name": "IT",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Andy Muschietti"
-    },
-    {
-        "id": 24,
-        "name": "Annabelle comes home",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "Gary Dauberman"
-    },
-    {
-        "id": 1,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 2,
-        "name": "Host",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Andy Newber"
-    },
-    {
-        "id": 3,
-        "name": "The Ring",
-        "yearReleased": "2004",
-        "language": "English",
-        "director": "Andy Newsir"
-    },
-    {
-        "id": 4,
-        "name": "Dahmer",
-        "yearReleased": "2002",
-        "language": "English",
-        "director": "David Jacobson"
-    },
-    {
-        "id": 5,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 6,
-        "name": "one missed call",
-        "yearReleased": "2008",
-        "language": "English",
-        "director": "Eric Vallete"
-    },
-    {
-        "id": 7,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 8,
-        "name": "Insidious",
-        "yearReleased": "2010",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 9,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "plazo"
-    },
-    {
-        "id": 10,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 11,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "paco plazo"
-    },
-    {
-        "id": 12,
-        "name": " The Omen in Devil Town ",
-        "yearReleased": "1993",
-        "language": "English",
-        "director": "Qumin Lee"
-    },
-    {
-        "id": 13,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 14,
-        "name": " 6 and 1 (In the Mind)",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "Sudhanshu Saria"
-    },
-    {
-        "id": 15,
-        "name": "Faz-me Companhia",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "João Pedro Rodrigues"
-    },
-    {
-        "id": 16,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 17,
-        "name": "Paranormal Activity",
-        "yearReleased": "2007",
-        "language": "English",
-        "director": "Oren Peli"
-    },
-    {
-        "id": 18,
-        "name": "Paranormal Activity 2",
-        "yearReleased": "2010",
-        "language": "English",
-        "director": "Tod Williams"
-    },
-    {
-        "id": 19,
-        "name": "Paranormal Activity 3",
-        "yearReleased": "2011",
-        "language": "English",
-        "director": "Henry joost,Ariel Schulman"
-    },
-    {
-        "id": 20,
-        "name": "Paranormal Activity 4",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "Henry joost,Ariel Schulman"
-    },
-    {
-        "id": 20,
-        "name": "Kanchana",
-        "yearReleased": "2016",
-        "language": "Tamil",
-        "director": "Indian Insan"
-    },
-    {
-        "id": 22,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 23,
-        "name": " Barbarian",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "TZach Cregger"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 20,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 25,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 26,
-        "name": "Videodrome",
-        "yearReleased": "1983",
-        "language": "English",
-        "director": " David Cronenberg"
-    },
-    {
-        "id": 27,
-        "name": " Horror Story",
-        "yearReleased": "2013",
-        "language": "Hindi",
-        "director": "Ayush Raina"
-    },
-    {
-        "id": 28,
-        "name": "The Exorcist",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Andy Newber"
-    },
-    {
-        "id": 29,
-        "name": "The Weird Man",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 30,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 31,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 32,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 33,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 34,
-        "name": "nightmare of the elm street",
-        "yearReleased": "1984",
-        "language": "English",
-        "director": "Wes Craven"
-    },
-    {
-        "id": 35,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {
-        "id": 36,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 37,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "The Unholy",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Evan Spiliotopoulos"
-    },
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 21,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 22,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 23,
-        "name": "nightmare of the elm street",
-        "yearReleased": "1984",
-        "language": "English",
-        "director": "Wes Craven"
-    },
-    {
-        "id": 24,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 26,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "The Unholy",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Evan Spiliotopoulos"
-    },
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 26,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "stree",
-        "yearReleased": "2020",
-        "language": "Hindi",
-        "director": "dev deol"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 24,
-        "name": "Dead Silence",
-        "yearReleased": "2007",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 21,
-        "name": "Mahal",
-        "yearReleased": "1949",
-        "language": "Hindi",
-        "director": "Kamal Amrohi"
-    },
-    {
-        "id": 30,
-        "name": "US",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "Jordan Peele"
-    },
-    {
-        "id": 50,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 21,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 28,
-        "name": "Midsommar",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": " Ari Aster"
-    },
-    {},
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 29,
-        "name": "Orphan",
-        "yearReleased": "2009",
-        "language": "English",
-        "director": "Jaume Collet-Serra"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 22,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {},
-    {
-        "id": 24,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 22,
-        "name": "Arundhati",
-        "yearReleased": "2009",
-        "language": "Telugu",
-        "director": "Kodi Ramakrishna"
-    },
-    {
-        "id": 25,
-        "name": "Nope",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Jordan Peele"
-    },
-    {
-        "id": 32,
-        "name": "Bhool Bhulaiyaa  ",
-        "yearReleased": "2007",
-        "language": "Hindi",
-        "director": "Priyadarshan"
-    },
-    {
-        "id": 32,
-        "name": "stree",
-        "yearReleased": "2019",
-        "language": "Hindi",
-        "director": "Amar Kaushik"
-    },
-    {
-        "id": 27,
-        "name": "sinister",
-        "yearReleased": "2012",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 27,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 28,
-        "name": "Train to Busan",
-        "yearReleased": " 2016",
-        "language": "korean",
-        "director": "Yeon Sang-ho"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 27,
-        "name": "sinister",
-        "yearReleased": "2012",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 27,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 28,
-        "name": "Train to Busan",
-        "yearReleased": " 2016",
-        "language": "korean",
-        "director": "Yeon Sang-ho"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 21,
-        "name": "The Nun",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Corin Hardy"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "shaapit",
-        "yearReleased": "2010",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 21,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "TZach Cregger"
-    },
-    {
-        "id": 20,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 55,
-        "name": "Malignant",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 24,
-        "name": "IT",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Andrés Muschietti"
-    },
-    {
-        "id": 26,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 21,
-        "name": "Anabella",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "John R. Leonetti"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 56,
-        "name": "Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 29,
-        "name": "Hereditary",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Ari Aster"
-    },
-    {
-        "id": 22,
-        "name": "Roohi",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Hardik Mehta"
-    },
-    {
-        "id": 23,
-        "name": "Stree",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Amar Kaushik"
-    },
-    {
-        "id": 26,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 7008,
-        "name": "Handjob Cabin",
-        "yearReleased": "2015",
-        "language": "English",
-        "director": "Bennet Silverman"
-    },
-    {
-        "id": 21,
-        "name": " Chhorii",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Vishal Furia"
-    },
-    {
-        "id": 27,
-        "name": "kanchan",
-        "yearReleased": "2013",
-        "language": "Hindi",
-        "director": "ssr"
-    },
-    {
-        "id": 21,
-        "name": "Host",
-        "yearRealeased": "2020",
-        "language": "English",
-        "director": "Rob Savage"
-    },
-    {
-        "id": 22,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 57,
-        "name": "Aftermath",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": " Peter Winther"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "Corin Hardy"
-    },
-    {
-        "id": 21,
-        "name": "stree",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "BANSALI"
-    },
-    {
-        "id": 21,
-        "name": "The Shining",
-        "yearReleased": "1980",
-        "language": "English",
-        "director": "Stanley Kubrick"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 57,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "English",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Old",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "M. Night Shyamalan"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 20,
-        "name": "Chhorii",
-        "yearReleased": "2021",
-        "language": "hindi",
-        "director": "Vishal Furia"
-    },
-    {
-        "id": 21,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Paco Plaza"
-    },
-    {
-        "id": 21,
-        "name": "6-5=2",
-        "yearReleased": "2014",
-        "language": "HINDI",
-        "director": "Bharat Jain"
-    },
-    {
-        "id": 22,
-        "name": "brahmastra",
-        "yearReleased": "2022",
-        "language": "HINDI",
-        "director": "Ayan Mukerji"
-    },
-    {
-        "id": 21,
-        "name": "IT'S ALIVE! ",
-        "yearReleased": "1974",
-        "language": "English",
-        "director": "Larry Cohen"
-    },
-    {
-        "id": 28,
-        "name": "The Grudge",
-        "yearReleased": "2004",
-        "language": "Japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 21,
-        "name": "Haunted – 3D",
-        "yearReleased": "2011",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 79,
-        "name": "The Ring",
-        "yearReleased": "2003",
-        "language": "English",
-        "director": "Gore Verbinski"
-    },
-    {
-        "id": 22,
-        "name": "The Conjuring 2",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 23,
-        "name": "Resident Evil",
-        "yearReleased": "2002",
-        "language": "English",
-        "director": "Paul W.S. Anderson"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "John boorman"
-    },
-    {
-        "id": 29,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 23,
-        "name": "IT",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Andy Muschietti"
-    },
-    {
-        "id": 24,
-        "name": "Get Out",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Jordan Peele"
-    },
-    {
-        "id": 1,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 2,
-        "name": "Host",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Andy Newber"
-    },
-    {
-        "id": 3,
-        "name": "The Ring",
-        "yearReleased": "2004",
-        "language": "English",
-        "director": "Andy Newsir"
-    },
-    {
-        "id": 4,
-        "name": "Dahmer",
-        "yearReleased": "2002",
-        "language": "English",
-        "director": "David Jacobson"
-    },
-    {
-        "id": 5,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 6,
-        "name": "one missed call",
-        "yearReleased": "2008",
-        "language": "English",
-        "director": "Eric Vallete"
-    },
-    {
-        "id": 7,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 8,
-        "name": "Insidious",
-        "yearReleased": "2010",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 9,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "plazo"
-    },
-    {
-        "id": 10,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 11,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "paco plazo"
-    },
-    {
-        "id": 12,
-        "name": " The Omen in Devil Town ",
-        "yearReleased": "1993",
-        "language": "English",
-        "director": "Qumin Lee"
-    },
-    {
-        "id": 13,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 14,
-        "name": " 6 and 1 (In the Mind)",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "Sudhanshu Saria"
-    },
-    {
-        "id": 15,
-        "name": "Faz-me Companhia",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "João Pedro Rodrigues"
-    },
-    {
-        "id": 16,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 17,
-        "name": "Paranormal Activity",
-        "yearReleased": "2007",
-        "language": "English",
-        "director": "Oren Peli"
-    },
-    {
-        "id": 18,
-        "name": "Paranormal Activity 2",
-        "yearReleased": "2010",
-        "language": "English",
-        "director": "Tod Williams"
-    },
-    {
-        "id": 19,
-        "name": "Paranormal Activity 3",
-        "yearReleased": "2011",
-        "language": "English",
-        "director": "Henry joost,Ariel Schulman"
-    },
-    {
-        "id": 20,
-        "name": "Paranormal Activity 4",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "Henry joost,Ariel Schulman"
-    },
-    {
-        "id": 20,
-        "name": "Kanchana",
-        "yearReleased": "2016",
-        "language": "Tamil",
-        "director": "Indian Insan"
-    },
-    {
-        "id": 22,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 23,
-        "name": " Barbarian",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "TZach Cregger"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 20,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 25,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 26,
-        "name": "Videodrome",
-        "yearReleased": "1983",
-        "language": "English",
-        "director": " David Cronenberg"
-    },
-    {
-        "id": 27,
-        "name": " Horror Story",
-        "yearReleased": "2013",
-        "language": "Hindi",
-        "director": "Ayush Raina"
-    },
-    {
-        "id": 28,
-        "name": "The Exorcist",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Andy Newber"
-    },
-    {
-        "id": 29,
-        "name": "The Weird Man",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 30,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 31,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 32,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 33,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 34,
-        "name": "nightmare of the elm street",
-        "yearReleased": "1984",
-        "language": "English",
-        "director": "Wes Craven"
-    },
-    {
-        "id": 35,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {
-        "id": 36,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 37,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "The Unholy",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Evan Spiliotopoulos"
-    },
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 21,
-        "name": "X",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Ti West"
-    },
-    {
-        "id": 22,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 23,
-        "name": "nightmare of the elm street",
-        "yearReleased": "1984",
-        "language": "English",
-        "director": "Wes Craven"
-    },
-    {
-        "id": 24,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 26,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "The Unholy",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Evan Spiliotopoulos"
-    },
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 26,
-        "name": "Alien: Covenant",
-        "yearReleased": " 2017",
-        "language": "English",
-        "director": "Ridley Scott"
-    },
-    {
-        "id": 27,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 21,
-        "name": "Dybbuk",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "Jay Krishnan"
-    },
-    {
-        "id": 28,
-        "name": "House Of Usher",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": "Roger Corman"
-    },
-    {
-        "id": 21,
-        "name": "stree",
-        "yearReleased": "2020",
-        "language": "Hindi",
-        "director": "dev deol"
-    },
-    {
-        "id": 21,
-        "name": "Psycho",
-        "yearReleased": "1960",
-        "language": "English",
-        "director": " Alfred Hitchcock"
-    },
-    {
-        "id": 24,
-        "name": "Dead Silence",
-        "yearReleased": "2007",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 21,
-        "name": "Mahal",
-        "yearReleased": "1949",
-        "language": "Hindi",
-        "director": "Kamal Amrohi"
-    },
-    {
-        "id": 30,
-        "name": "US",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "Jordan Peele"
-    },
-    {
-        "id": 50,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 21,
-        "name": "Annabelle",
-        "yearReleased": "2014",
-        "language": "English",
-        "director": " John R. Leonetti"
-    },
-    {
-        "id": 28,
-        "name": "Midsommar",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": " Ari Aster"
-    },
-    {},
-    {
-        "id": 23,
-        "name": "The Midnigth club",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Mike Flannagan"
-    },
-    {
-        "id": 29,
-        "name": "Orphan",
-        "yearReleased": "2009",
-        "language": "English",
-        "director": "Jaume Collet-Serra"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 22,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Anees Bazmee"
-    },
-    {},
-    {
-        "id": 24,
-        "name": "6-5=2",
-        "yearReleased": "2013",
-        "language": "Kannada",
-        "director": "K S Ashoka"
-    },
-    {
-        "id": 22,
-        "name": "Arundhati",
-        "yearReleased": "2009",
-        "language": "Telugu",
-        "director": "Kodi Ramakrishna"
-    },
-    {
-        "id": 25,
-        "name": "Nope",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "Jordan Peele"
-    },
-    {
-        "id": 32,
-        "name": "Bhool Bhulaiyaa  ",
-        "yearReleased": "2007",
-        "language": "Hindi",
-        "director": "Priyadarshan"
-    },
-    {
-        "id": 32,
-        "name": "stree",
-        "yearReleased": "2019",
-        "language": "Hindi",
-        "director": "Amar Kaushik"
-    },
-    {
-        "id": 27,
-        "name": "sinister",
-        "yearReleased": "2012",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 27,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 28,
-        "name": "Train to Busan",
-        "yearReleased": " 2016",
-        "language": "korean",
-        "director": "Yeon Sang-ho"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 27,
-        "name": "sinister",
-        "yearReleased": "2012",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 27,
-        "name": "1920",
-        "yearReleased": "2008",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 28,
-        "name": "Train to Busan",
-        "yearReleased": " 2016",
-        "language": "korean",
-        "director": "Yeon Sang-ho"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 21,
-        "name": "The Nun",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Corin Hardy"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "shaapit",
-        "yearReleased": "2010",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearReleased": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 21,
-        "name": "Bhool Bhulaiyaa 2",
-        "yearReleased": "2022",
-        "language": "English",
-        "director": "TZach Cregger"
-    },
-    {
-        "id": 20,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 55,
-        "name": "Malignant",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 24,
-        "name": "IT",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Andrés Muschietti"
-    },
-    {
-        "id": 26,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 25,
-        "name": "Bhoot",
-        "yearReleased": "2022",
-        "language": "Hindi",
-        "director": "Bhanu Pratap Singh"
-    },
-    {
-        "id": 21,
-        "name": "Anabella",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "John R. Leonetti"
-    },
-    {
-        "id": 27,
-        "name": "sinister2",
-        "yearReleased": "2015",
-        "language": "english",
-        "director": "scott derrickson"
-    },
-    {
-        "id": 33,
-        "name": "Tumbad",
-        "yearReleased": "2018",
-        "language": "Hindi",
-        "director": "Rahi Barve"
-    },
-    {
-        "id": 99,
-        "name": "kalo",
-        "yearReleased": "1960",
-        "language": "hindi",
-        "director": "pata nahi"
-    },
-    {
-        "id": 27,
-        "name": "Bhootkaal",
-        "yearRelea  sed": "2003",
-        "language": "Hindi",
-        "director": "Ram Gopal Varma"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 56,
-        "name": "Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 29,
-        "name": "Hereditary",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Ari Aster"
-    },
-    {
-        "id": 22,
-        "name": "Roohi",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Hardik Mehta"
-    },
-    {
-        "id": 23,
-        "name": "Stree",
-        "yearReleased": "2018",
-        "language": "English",
-        "director": "Amar Kaushik"
-    },
-    {
-        "id": 26,
-        "name": "Host",
-        "yearReleased": "2020",
-        "language": "English",
-        "director": "Andy dataser"
-    },
-    {
-        "id": 7008,
-        "name": "Handjob Cabin",
-        "yearReleased": "2015",
-        "language": "English",
-        "director": "Bennet Silverman"
-    },
-    {
-        "id": 21,
-        "name": " Chhorii",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Vishal Furia"
-    },
-    {
-        "id": 27,
-        "name": "kanchan",
-        "yearReleased": "2013",
-        "language": "Hindi",
-        "director": "ssr"
-    },
-    {
-        "id": 21,
-        "name": "Host",
-        "yearRealeased": "2020",
-        "language": "English",
-        "director": "Rob Savage"
-    },
-    {
-        "id": 22,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 57,
-        "name": "Aftermath",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": " Peter Winther"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "Corin Hardy"
-    },
-    {
-        "id": 21,
-        "name": "stree",
-        "yearReleased": "2021",
-        "language": "Hindi",
-        "director": "BANSALI"
-    },
-    {
-        "id": 21,
-        "name": "The Shining",
-        "yearReleased": "1980",
-        "language": "English",
-        "director": "Stanley Kubrick"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 57,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "English",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Old",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "M. Night Shyamalan"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 56,
-        "name": "Lights Out ",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "David F. Sandberg"
-    },
-    {
-        "id": 20,
-        "name": "Chhorii",
-        "yearReleased": "2021",
-        "language": "hindi",
-        "director": "Vishal Furia"
-    },
-    {
-        "id": 21,
-        "name": "Veronica",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Paco Plaza"
-    },
-    {
-        "id": 21,
-        "name": "6-5=2",
-        "yearReleased": "2014",
-        "language": "HINDI",
-        "director": "Bharat Jain"
-    },
-    {
-        "id": 22,
-        "name": "brahmastra",
-        "yearReleased": "2022",
-        "language": "HINDI",
-        "director": "Ayan Mukerji"
-    },
-    {
-        "id": 21,
-        "name": "IT'S ALIVE! ",
-        "yearReleased": "1974",
-        "language": "English",
-        "director": "Larry Cohen"
-    },
-    {
-        "id": 28,
-        "name": "The Grudge",
-        "yearReleased": "2004",
-        "language": "Japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 21,
-        "name": "Haunted – 3D",
-        "yearReleased": "2011",
-        "language": "Hindi",
-        "director": "Vikram Bhatt"
-    },
-    {
-        "id": 52,
-        "name": "Alone",
-        "yearReleased": "2015",
-        "language": "Hindi",
-        "director": "Bhushan Patel"
-    },
-    {
-        "id": 53,
-        "name": "vyanki the Dian",
-        "yearReleased": "2022",
-        "language": "Russian",
-        "director": "Vishal chauhan"
-    },
-    {
-        "id": 54,
-        "name": "The Woman in Black",
-        "yearReleased": "2012",
-        "language": "English",
-        "director": "James Watkins"
-    },
-    {
-        "id": 55,
-        "name": "Innocent Curse",
-        "yearReleased": "2017",
-        "language": "japanese",
-        "director": "Takashi Shimizu"
-    },
-    {
-        "id": 79,
-        "name": "The Ring",
-        "yearReleased": "2003",
-        "language": "English",
-        "director": "Gore Verbinski"
-    },
-    {
-        "id": 22,
-        "name": "The Conjuring 2",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 23,
-        "name": "Resident Evil",
-        "yearReleased": "2002",
-        "language": "English",
-        "director": "Paul W.S. Anderson"
-    },
-    {
-        "id": 21,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "John boorman"
-    },
-    {
-        "id": 29,
-        "name": "The Conjuring",
-        "yearReleased": "2013",
-        "language": "English",
-        "director": "James Wan"
-    },
-    {
-        "id": 23,
-        "name": "IT",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Andy Muschietti"
-    },
-    {
-        "id": 24,
-        "name": "Get Out",
-        "yearReleased": "2017",
-        "language": "English",
-        "director": "Jordan Peele"
-    },
-    {
-        "id": 25,
-        "name": "The Exorcism of Emily Rose",
-        "yearReleased": "2005 ",
-        "language": "English",
-        "director": "Scott Derrickson"
-    },
-    {
-        "id": 26,
-        "name": "The Unholy",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Evan Spiliotopoulos"
-    },
-    {
-        "id": 333,
-        "name": "Pontypool",
-        "yearReleased": "2008",
-        "language": "English",
-        "director": "Bruce McDonald"
-    },
-    {
-        "id": 25,
-        "name": "The Exorcism of Emily Rose",
-        "yearReleased": "2005 ",
-        "language": "English",
-        "director": "Scott Derrickson"
-    },
-    {
-        "id": 26,
-        "name": "The Unholy",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Evan Spiliotopoulos"
-    },
-    {
-        "id": 27,
-        "name": "10 Cloverfield Lane",
-        "yearReleased": "2016",
-        "language": "English",
-        "director": "Dan Trachtenberg"
-    },
-    {
-        "id": 27,
-        "name": "Martyyrs",
-        "yearReleased": "2008",
-        "language": "French",
-        "director": "Pascal Laugier"
-    },
-    {
-        "id": 55,
-        "name": "Kanchana",
-        "yearReleased": "2017",
-        "language": "hindi",
-        "director": "P.Vas Shivalinga"
-    },
-    {
-        "id": 28,
-        "name": "Bhootiya",
-        "yearReleased": "2020",
-        "language": "Hindi",
-        "director": "Vishal Dadlanni"
-    },
-    {
-        "id": 100,
-        "name": "Wrong Turn",
-        "yearReleased": "2021",
-        "language": "English",
-        "director": "Mike P. Nelson"
-    },
-    {
-        "id": 102,
-        "name": "Chhorii",
-        "yearReleased": "2021",
-        "language": "hindi",
-        "director": "Vishal Furia"
-    },
-    {
-        "id": 101,
-        "name": "The Exorcist",
-        "yearReleased": "1973",
-        "language": "English",
-        "director": "William Friedkin"
-    },
-    {
-        "id": 114,
-        "name": "The Amityville Horror",
-        "yearReleased": "1979",
-        "language": "English",
-        "director": "Stuart Rosenberg"
-    },
-    {
-        "id": 201,
-        "name": "Avatar",
-        "yearReleased": "2009",
-        "language": "English",
-        "director": "James Cameron"
-    },
-    {
-        "id": 152,
-        "name": "13B: Fear Has a New Address",
-        "yearReleased": "2009",
-        "language": "Hindi",
-        "director": "Vikram Kumar"
-    },
-    {
-        "id": 673,
-        "name": "A Serbian Film",
-        "yearReleased": "2010",
-        "language": "Serbian, English, Swedish",
-        "director": "Srdjan Spasojevic"
-    },
-    {
-        "id": 674,
-        "name": "8: A South African Horror Story",
-        "yearReleased": "2019",
-        "language": "English",
-        "director": "Harold Holscher"
-    }
+  {
+    "id": 1,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 3,
+    "name": "The Ring",
+    "yearReleased": "2004",
+    "language": "English",
+    "director": "Andy Newsir"
+  },
+  {
+    "id": 4,
+    "name": "Dahmer",
+    "yearReleased": "2002",
+    "language": "English",
+    "director": "David Jacobson"
+  },
+  {
+    "id": 5,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 6,
+    "name": "One Missed Call",
+    "yearReleased": "2008",
+    "language": "English",
+    "director": "Eric Vallete"
+  },
+  {
+    "id": 7,
+    "name": "The Midnigth Club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 8,
+    "name": "Insidious",
+    "yearReleased": "2010",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 9,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "plazo"
+  },
+  {
+    "id": 10,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 11,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "paco plazo"
+  },
+  {
+    "id": 12,
+    "name": " The Omen in Devil Town ",
+    "yearReleased": "1993",
+    "language": "English",
+    "director": "Qumin Lee"
+  },
+  {
+    "id": 13,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 14,
+    "name": " 6 and 1 (In the Mind)",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "Sudhanshu Saria"
+  },
+  {
+    "id": 15,
+    "name": "Faz-me Companhia",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "João Pedro Rodrigues"
+  },
+  {
+    "id": 16,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 17,
+    "name": "Paranormal Activity",
+    "yearReleased": "2007",
+    "language": "English",
+    "director": "Oren Peli"
+  },
+  {
+    "id": 18,
+    "name": "Paranormal Activity 2",
+    "yearReleased": "2010",
+    "language": "English",
+    "director": "Tod Williams"
+  },
+  {
+    "id": 19,
+    "name": "Paranormal Activity 3",
+    "yearReleased": "2011",
+    "language": "English",
+    "director": "Henry joost,Ariel Schulman"
+  },
+  {
+    "id": 20,
+    "name": "Paranormal Activity 4",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "Henry joost,Ariel Schulman"
+  },
+  {
+    "id": 20,
+    "name": "Kanchana",
+    "yearReleased": "2016",
+    "language": "Tamil",
+    "director": "Indian Insan"
+  },
+  {
+    "id": 22,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 23,
+    "name": " Barbarian",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "TZach Cregger"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 20,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 25,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 26,
+    "name": "Videodrome",
+    "yearReleased": "1983",
+    "language": "English",
+    "director": " David Cronenberg"
+  },
+  {
+    "id": 27,
+    "name": " Horror Story",
+    "yearReleased": "2013",
+    "language": "Hindi",
+    "director": "Ayush Raina"
+  },
+  {
+    "id": 28,
+    "name": "The Exorcist",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Andy Newber"
+  },
+  {
+    "id": 29,
+    "name": "The Weird Man",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 30,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 31,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 32,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 33,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 34,
+    "name": "nightmare of the elm street",
+    "yearReleased": "1984",
+    "language": "English",
+    "director": "Wes Craven"
+  },
+  {
+    "id": 35,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {
+    "id": 36,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 37,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "The Unholy",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Evan Spiliotopoulos"
+  },
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 21,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 22,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 23,
+    "name": "nightmare of the elm street",
+    "yearReleased": "1984",
+    "language": "English",
+    "director": "Wes Craven"
+  },
+  {
+    "id": 24,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 26,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "The Unholy",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Evan Spiliotopoulos"
+  },
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 26,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "stree",
+    "yearReleased": "2020",
+    "language": "Hindi",
+    "director": "dev deol"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 24,
+    "name": "Dead Silence",
+    "yearReleased": "2007",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 21,
+    "name": "Mahal",
+    "yearReleased": "1949",
+    "language": "Hindi",
+    "director": "Kamal Amrohi"
+  },
+  {
+    "id": 30,
+    "name": "US",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "Jordan Peele"
+  },
+  {
+    "id": 50,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 21,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 28,
+    "name": "Midsommar",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": " Ari Aster"
+  },
+  {},
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 29,
+    "name": "Orphan",
+    "yearReleased": "2009",
+    "language": "English",
+    "director": "Jaume Collet-Serra"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 22,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {},
+  {
+    "id": 24,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 22,
+    "name": "Arundhati",
+    "yearReleased": "2009",
+    "language": "Telugu",
+    "director": "Kodi Ramakrishna"
+  },
+  {
+    "id": 25,
+    "name": "Nope",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Jordan Peele"
+  },
+  {
+    "id": 32,
+    "name": "Bhool Bhulaiyaa  ",
+    "yearReleased": "2007",
+    "language": "Hindi",
+    "director": "Priyadarshan"
+  },
+  {
+    "id": 32,
+    "name": "stree",
+    "yearReleased": "2019",
+    "language": "Hindi",
+    "director": "Amar Kaushik"
+  },
+  {
+    "id": 27,
+    "name": "sinister",
+    "yearReleased": "2012",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 27,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 28,
+    "name": "Train to Busan",
+    "yearReleased": " 2016",
+    "language": "korean",
+    "director": "Yeon Sang-ho"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 27,
+    "name": "sinister",
+    "yearReleased": "2012",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 27,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 28,
+    "name": "Train to Busan",
+    "yearReleased": " 2016",
+    "language": "korean",
+    "director": "Yeon Sang-ho"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 21,
+    "name": "The Nun",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Corin Hardy"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "shaapit",
+    "yearReleased": "2010",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 21,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "TZach Cregger"
+  },
+  {
+    "id": 20,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 55,
+    "name": "Malignant",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 24,
+    "name": "IT",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Andrés Muschietti"
+  },
+  {
+    "id": 26,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 21,
+    "name": "Anabella",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "John R. Leonetti"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 56,
+    "name": "Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 29,
+    "name": "Hereditary",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Ari Aster"
+  },
+  {
+    "id": 22,
+    "name": "Roohi",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Hardik Mehta"
+  },
+  {
+    "id": 23,
+    "name": "Stree",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Amar Kaushik"
+  },
+  {
+    "id": 26,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 7008,
+    "name": "Handjob Cabin",
+    "yearReleased": "2015",
+    "language": "English",
+    "director": "Bennet Silverman"
+  },
+  {
+    "id": 21,
+    "name": " Chhorii",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Vishal Furia"
+  },
+  {
+    "id": 27,
+    "name": "kanchan",
+    "yearReleased": "2013",
+    "language": "Hindi",
+    "director": "ssr"
+  },
+  {
+    "id": 21,
+    "name": "Host",
+    "yearRealeased": "2020",
+    "language": "English",
+    "director": "Rob Savage"
+  },
+  {
+    "id": 22,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "Corin Hardy"
+  },
+  {
+    "id": 21,
+    "name": "stree",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "BANSALI"
+  },
+  {
+    "id": 21,
+    "name": "The Shining",
+    "yearReleased": "1980",
+    "language": "English",
+    "director": "Stanley Kubrick"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 57,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "English",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Old",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "M. Night Shyamalan"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 20,
+    "name": "Chhorii",
+    "yearReleased": "2021",
+    "language": "hindi",
+    "director": "Vishal Furia"
+  },
+  {
+    "id": 21,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Paco Plaza"
+  },
+  {
+    "id": 21,
+    "name": "6-5=2",
+    "yearReleased": "2014",
+    "language": "HINDI",
+    "director": "Bharat Jain"
+  },
+  {
+    "id": 22,
+    "name": "brahmastra",
+    "yearReleased": "2022",
+    "language": "HINDI",
+    "director": "Ayan Mukerji"
+  },
+  {
+    "id": 21,
+    "name": "IT'S ALIVE! ",
+    "yearReleased": "1974",
+    "language": "English",
+    "director": "Larry Cohen"
+  },
+  {
+    "id": 28,
+    "name": "The Grudge",
+    "yearReleased": "2004",
+    "language": "Japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 21,
+    "name": "Haunted – 3D",
+    "yearReleased": "2011",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 79,
+    "name": "The Ring",
+    "yearReleased": "2003",
+    "language": "English",
+    "director": "Gore Verbinski"
+  },
+  {
+    "id": 22,
+    "name": "The Conjuring 2",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 23,
+    "name": "Resident Evil",
+    "yearReleased": "2002",
+    "language": "English",
+    "director": "Paul W.S. Anderson"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "John boorman"
+  },
+  {
+    "id": 29,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 23,
+    "name": "IT",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Andy Muschietti"
+  },
+  {
+    "id": 24,
+    "name": "Get Out",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Jordan Peele"
+  },
+  {
+    "id": 231,
+    "name": "Halloween Kills",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "David Gordon Green"
+  },
+  {
+    "id": 1,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 2,
+    "name": "Host",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Andy Newber"
+  },
+  {
+    "id": 3,
+    "name": "The Ring",
+    "yearReleased": "2004",
+    "language": "English",
+    "director": "Andy Newsir"
+  },
+  {
+    "id": 4,
+    "name": "Dahmer",
+    "yearReleased": "2002",
+    "language": "English",
+    "director": "David Jacobson"
+  },
+  {
+    "id": 5,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 6,
+    "name": "one missed call",
+    "yearReleased": "2008",
+    "language": "English",
+    "director": "Eric Vallete"
+  },
+  {
+    "id": 7,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 8,
+    "name": "Insidious",
+    "yearReleased": "2010",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 9,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "plazo"
+  },
+  {
+    "id": 10,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 11,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "paco plazo"
+  },
+  {
+    "id": 12,
+    "name": " The Omen in Devil Town ",
+    "yearReleased": "1993",
+    "language": "English",
+    "director": "Qumin Lee"
+  },
+  {
+    "id": 13,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 14,
+    "name": " 6 and 1 (In the Mind)",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "Sudhanshu Saria"
+  },
+  {
+    "id": 15,
+    "name": "Faz-me Companhia",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "João Pedro Rodrigues"
+  },
+  {
+    "id": 16,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 17,
+    "name": "Paranormal Activity",
+    "yearReleased": "2007",
+    "language": "English",
+    "director": "Oren Peli"
+  },
+  {
+    "id": 18,
+    "name": "Paranormal Activity 2",
+    "yearReleased": "2010",
+    "language": "English",
+    "director": "Tod Williams"
+  },
+  {
+    "id": 19,
+    "name": "Paranormal Activity 3",
+    "yearReleased": "2011",
+    "language": "English",
+    "director": "Henry joost,Ariel Schulman"
+  },
+  {
+    "id": 20,
+    "name": "Paranormal Activity 4",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "Henry joost,Ariel Schulman"
+  },
+  {
+    "id": 20,
+    "name": "Kanchana",
+    "yearReleased": "2016",
+    "language": "Tamil",
+    "director": "Indian Insan"
+  },
+  {
+    "id": 22,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 23,
+    "name": " Barbarian",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "TZach Cregger"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 20,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 25,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 26,
+    "name": "Videodrome",
+    "yearReleased": "1983",
+    "language": "English",
+    "director": " David Cronenberg"
+  },
+  {
+    "id": 27,
+    "name": " Horror Story",
+    "yearReleased": "2013",
+    "language": "Hindi",
+    "director": "Ayush Raina"
+  },
+  {
+    "id": 28,
+    "name": "The Exorcist",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Andy Newber"
+  },
+  {
+    "id": 29,
+    "name": "The Weird Man",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 30,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 31,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 32,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 33,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 34,
+    "name": "nightmare of the elm street",
+    "yearReleased": "1984",
+    "language": "English",
+    "director": "Wes Craven"
+  },
+  {
+    "id": 35,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {
+    "id": 36,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 37,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "The Unholy",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Evan Spiliotopoulos"
+  },
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 21,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 22,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 23,
+    "name": "nightmare of the elm street",
+    "yearReleased": "1984",
+    "language": "English",
+    "director": "Wes Craven"
+  },
+  {
+    "id": 24,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 26,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "The Unholy",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Evan Spiliotopoulos"
+  },
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 26,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "stree",
+    "yearReleased": "2020",
+    "language": "Hindi",
+    "director": "dev deol"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 24,
+    "name": "Dead Silence",
+    "yearReleased": "2007",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 21,
+    "name": "Mahal",
+    "yearReleased": "1949",
+    "language": "Hindi",
+    "director": "Kamal Amrohi"
+  },
+  {
+    "id": 30,
+    "name": "US",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "Jordan Peele"
+  },
+  {
+    "id": 50,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 21,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 28,
+    "name": "Midsommar",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": " Ari Aster"
+  },
+  {},
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 29,
+    "name": "Orphan",
+    "yearReleased": "2009",
+    "language": "English",
+    "director": "Jaume Collet-Serra"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 22,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {},
+  {
+    "id": 24,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 22,
+    "name": "Arundhati",
+    "yearReleased": "2009",
+    "language": "Telugu",
+    "director": "Kodi Ramakrishna"
+  },
+  {
+    "id": 25,
+    "name": "Nope",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Jordan Peele"
+  },
+  {
+    "id": 32,
+    "name": "Bhool Bhulaiyaa  ",
+    "yearReleased": "2007",
+    "language": "Hindi",
+    "director": "Priyadarshan"
+  },
+  {
+    "id": 32,
+    "name": "stree",
+    "yearReleased": "2019",
+    "language": "Hindi",
+    "director": "Amar Kaushik"
+  },
+  {
+    "id": 27,
+    "name": "sinister",
+    "yearReleased": "2012",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 27,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 28,
+    "name": "Train to Busan",
+    "yearReleased": " 2016",
+    "language": "korean",
+    "director": "Yeon Sang-ho"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 27,
+    "name": "sinister",
+    "yearReleased": "2012",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 27,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 28,
+    "name": "Train to Busan",
+    "yearReleased": " 2016",
+    "language": "korean",
+    "director": "Yeon Sang-ho"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 21,
+    "name": "The Nun",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Corin Hardy"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "shaapit",
+    "yearReleased": "2010",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 21,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "TZach Cregger"
+  },
+  {
+    "id": 20,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 55,
+    "name": "Malignant",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 24,
+    "name": "IT",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Andrés Muschietti"
+  },
+  {
+    "id": 26,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 21,
+    "name": "Anabella",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "John R. Leonetti"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 56,
+    "name": "Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 29,
+    "name": "Hereditary",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Ari Aster"
+  },
+  {
+    "id": 22,
+    "name": "Roohi",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Hardik Mehta"
+  },
+  {
+    "id": 23,
+    "name": "Stree",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Amar Kaushik"
+  },
+  {
+    "id": 26,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 7008,
+    "name": "Handjob Cabin",
+    "yearReleased": "2015",
+    "language": "English",
+    "director": "Bennet Silverman"
+  },
+  {
+    "id": 21,
+    "name": " Chhorii",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Vishal Furia"
+  },
+  {
+    "id": 27,
+    "name": "kanchan",
+    "yearReleased": "2013",
+    "language": "Hindi",
+    "director": "ssr"
+  },
+  {
+    "id": 21,
+    "name": "Host",
+    "yearRealeased": "2020",
+    "language": "English",
+    "director": "Rob Savage"
+  },
+  {
+    "id": 22,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "Corin Hardy"
+  },
+  {
+    "id": 21,
+    "name": "stree",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "BANSALI"
+  },
+  {
+    "id": 21,
+    "name": "The Shining",
+    "yearReleased": "1980",
+    "language": "English",
+    "director": "Stanley Kubrick"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 57,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "English",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Old",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "M. Night Shyamalan"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 20,
+    "name": "Chhorii",
+    "yearReleased": "2021",
+    "language": "hindi",
+    "director": "Vishal Furia"
+  },
+  {
+    "id": 21,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Paco Plaza"
+  },
+  {
+    "id": 21,
+    "name": "6-5=2",
+    "yearReleased": "2014",
+    "language": "HINDI",
+    "director": "Bharat Jain"
+  },
+  {
+    "id": 22,
+    "name": "brahmastra",
+    "yearReleased": "2022",
+    "language": "HINDI",
+    "director": "Ayan Mukerji"
+  },
+  {
+    "id": 21,
+    "name": "IT'S ALIVE! ",
+    "yearReleased": "1974",
+    "language": "English",
+    "director": "Larry Cohen"
+  },
+  {
+    "id": 28,
+    "name": "The Grudge",
+    "yearReleased": "2004",
+    "language": "Japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 21,
+    "name": "Haunted – 3D",
+    "yearReleased": "2011",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 79,
+    "name": "The Ring",
+    "yearReleased": "2003",
+    "language": "English",
+    "director": "Gore Verbinski"
+  },
+  {
+    "id": 22,
+    "name": "The Conjuring 2",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 23,
+    "name": "Resident Evil",
+    "yearReleased": "2002",
+    "language": "English",
+    "director": "Paul W.S. Anderson"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "John boorman"
+  },
+  {
+    "id": 29,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 23,
+    "name": "IT",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Andy Muschietti"
+  },
+  {
+    "id": 24,
+    "name": "Annabelle comes home",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "Gary Dauberman"
+  },
+  {
+    "id": 1,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 2,
+    "name": "Host",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Andy Newber"
+  },
+  {
+    "id": 3,
+    "name": "The Ring",
+    "yearReleased": "2004",
+    "language": "English",
+    "director": "Andy Newsir"
+  },
+  {
+    "id": 4,
+    "name": "Dahmer",
+    "yearReleased": "2002",
+    "language": "English",
+    "director": "David Jacobson"
+  },
+  {
+    "id": 5,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 6,
+    "name": "one missed call",
+    "yearReleased": "2008",
+    "language": "English",
+    "director": "Eric Vallete"
+  },
+  {
+    "id": 7,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 8,
+    "name": "Insidious",
+    "yearReleased": "2010",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 9,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "plazo"
+  },
+  {
+    "id": 10,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 11,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "paco plazo"
+  },
+  {
+    "id": 12,
+    "name": " The Omen in Devil Town ",
+    "yearReleased": "1993",
+    "language": "English",
+    "director": "Qumin Lee"
+  },
+  {
+    "id": 13,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 14,
+    "name": " 6 and 1 (In the Mind)",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "Sudhanshu Saria"
+  },
+  {
+    "id": 15,
+    "name": "Faz-me Companhia",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "João Pedro Rodrigues"
+  },
+  {
+    "id": 16,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 17,
+    "name": "Paranormal Activity",
+    "yearReleased": "2007",
+    "language": "English",
+    "director": "Oren Peli"
+  },
+  {
+    "id": 18,
+    "name": "Paranormal Activity 2",
+    "yearReleased": "2010",
+    "language": "English",
+    "director": "Tod Williams"
+  },
+  {
+    "id": 19,
+    "name": "Paranormal Activity 3",
+    "yearReleased": "2011",
+    "language": "English",
+    "director": "Henry joost,Ariel Schulman"
+  },
+  {
+    "id": 20,
+    "name": "Paranormal Activity 4",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "Henry joost,Ariel Schulman"
+  },
+  {
+    "id": 20,
+    "name": "Kanchana",
+    "yearReleased": "2016",
+    "language": "Tamil",
+    "director": "Indian Insan"
+  },
+  {
+    "id": 22,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 23,
+    "name": " Barbarian",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "TZach Cregger"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 20,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 25,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 26,
+    "name": "Videodrome",
+    "yearReleased": "1983",
+    "language": "English",
+    "director": " David Cronenberg"
+  },
+  {
+    "id": 27,
+    "name": " Horror Story",
+    "yearReleased": "2013",
+    "language": "Hindi",
+    "director": "Ayush Raina"
+  },
+  {
+    "id": 28,
+    "name": "The Exorcist",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Andy Newber"
+  },
+  {
+    "id": 29,
+    "name": "The Weird Man",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 30,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 31,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 32,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 33,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 34,
+    "name": "nightmare of the elm street",
+    "yearReleased": "1984",
+    "language": "English",
+    "director": "Wes Craven"
+  },
+  {
+    "id": 35,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {
+    "id": 36,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 37,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "The Unholy",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Evan Spiliotopoulos"
+  },
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 21,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 22,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 23,
+    "name": "nightmare of the elm street",
+    "yearReleased": "1984",
+    "language": "English",
+    "director": "Wes Craven"
+  },
+  {
+    "id": 24,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 26,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "The Unholy",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Evan Spiliotopoulos"
+  },
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 26,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "stree",
+    "yearReleased": "2020",
+    "language": "Hindi",
+    "director": "dev deol"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 24,
+    "name": "Dead Silence",
+    "yearReleased": "2007",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 21,
+    "name": "Mahal",
+    "yearReleased": "1949",
+    "language": "Hindi",
+    "director": "Kamal Amrohi"
+  },
+  {
+    "id": 30,
+    "name": "US",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "Jordan Peele"
+  },
+  {
+    "id": 50,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 21,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 28,
+    "name": "Midsommar",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": " Ari Aster"
+  },
+  {},
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 29,
+    "name": "Orphan",
+    "yearReleased": "2009",
+    "language": "English",
+    "director": "Jaume Collet-Serra"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 22,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {},
+  {
+    "id": 24,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 22,
+    "name": "Arundhati",
+    "yearReleased": "2009",
+    "language": "Telugu",
+    "director": "Kodi Ramakrishna"
+  },
+  {
+    "id": 25,
+    "name": "Nope",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Jordan Peele"
+  },
+  {
+    "id": 32,
+    "name": "Bhool Bhulaiyaa  ",
+    "yearReleased": "2007",
+    "language": "Hindi",
+    "director": "Priyadarshan"
+  },
+  {
+    "id": 32,
+    "name": "stree",
+    "yearReleased": "2019",
+    "language": "Hindi",
+    "director": "Amar Kaushik"
+  },
+  {
+    "id": 27,
+    "name": "sinister",
+    "yearReleased": "2012",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 27,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 28,
+    "name": "Train to Busan",
+    "yearReleased": " 2016",
+    "language": "korean",
+    "director": "Yeon Sang-ho"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 27,
+    "name": "sinister",
+    "yearReleased": "2012",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 27,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 28,
+    "name": "Train to Busan",
+    "yearReleased": " 2016",
+    "language": "korean",
+    "director": "Yeon Sang-ho"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 21,
+    "name": "The Nun",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Corin Hardy"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "shaapit",
+    "yearReleased": "2010",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 21,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "TZach Cregger"
+  },
+  {
+    "id": 20,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 55,
+    "name": "Malignant",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 24,
+    "name": "IT",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Andrés Muschietti"
+  },
+  {
+    "id": 26,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 21,
+    "name": "Anabella",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "John R. Leonetti"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 56,
+    "name": "Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 29,
+    "name": "Hereditary",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Ari Aster"
+  },
+  {
+    "id": 22,
+    "name": "Roohi",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Hardik Mehta"
+  },
+  {
+    "id": 23,
+    "name": "Stree",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Amar Kaushik"
+  },
+  {
+    "id": 26,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 7008,
+    "name": "Handjob Cabin",
+    "yearReleased": "2015",
+    "language": "English",
+    "director": "Bennet Silverman"
+  },
+  {
+    "id": 21,
+    "name": " Chhorii",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Vishal Furia"
+  },
+  {
+    "id": 27,
+    "name": "kanchan",
+    "yearReleased": "2013",
+    "language": "Hindi",
+    "director": "ssr"
+  },
+  {
+    "id": 21,
+    "name": "Host",
+    "yearRealeased": "2020",
+    "language": "English",
+    "director": "Rob Savage"
+  },
+  {
+    "id": 22,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 57,
+    "name": "Aftermath",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": " Peter Winther"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "Corin Hardy"
+  },
+  {
+    "id": 21,
+    "name": "stree",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "BANSALI"
+  },
+  {
+    "id": 21,
+    "name": "The Shining",
+    "yearReleased": "1980",
+    "language": "English",
+    "director": "Stanley Kubrick"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 57,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "English",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Old",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "M. Night Shyamalan"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 20,
+    "name": "Chhorii",
+    "yearReleased": "2021",
+    "language": "hindi",
+    "director": "Vishal Furia"
+  },
+  {
+    "id": 21,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Paco Plaza"
+  },
+  {
+    "id": 21,
+    "name": "6-5=2",
+    "yearReleased": "2014",
+    "language": "HINDI",
+    "director": "Bharat Jain"
+  },
+  {
+    "id": 22,
+    "name": "brahmastra",
+    "yearReleased": "2022",
+    "language": "HINDI",
+    "director": "Ayan Mukerji"
+  },
+  {
+    "id": 21,
+    "name": "IT'S ALIVE! ",
+    "yearReleased": "1974",
+    "language": "English",
+    "director": "Larry Cohen"
+  },
+  {
+    "id": 28,
+    "name": "The Grudge",
+    "yearReleased": "2004",
+    "language": "Japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 21,
+    "name": "Haunted – 3D",
+    "yearReleased": "2011",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 79,
+    "name": "The Ring",
+    "yearReleased": "2003",
+    "language": "English",
+    "director": "Gore Verbinski"
+  },
+  {
+    "id": 22,
+    "name": "The Conjuring 2",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 23,
+    "name": "Resident Evil",
+    "yearReleased": "2002",
+    "language": "English",
+    "director": "Paul W.S. Anderson"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "John boorman"
+  },
+  {
+    "id": 29,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 23,
+    "name": "IT",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Andy Muschietti"
+  },
+  {
+    "id": 24,
+    "name": "Get Out",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Jordan Peele"
+  },
+  {
+    "id": 1,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 2,
+    "name": "Host",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Andy Newber"
+  },
+  {
+    "id": 3,
+    "name": "The Ring",
+    "yearReleased": "2004",
+    "language": "English",
+    "director": "Andy Newsir"
+  },
+  {
+    "id": 4,
+    "name": "Dahmer",
+    "yearReleased": "2002",
+    "language": "English",
+    "director": "David Jacobson"
+  },
+  {
+    "id": 5,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 6,
+    "name": "one missed call",
+    "yearReleased": "2008",
+    "language": "English",
+    "director": "Eric Vallete"
+  },
+  {
+    "id": 7,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 8,
+    "name": "Insidious",
+    "yearReleased": "2010",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 9,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "plazo"
+  },
+  {
+    "id": 10,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 11,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "paco plazo"
+  },
+  {
+    "id": 12,
+    "name": " The Omen in Devil Town ",
+    "yearReleased": "1993",
+    "language": "English",
+    "director": "Qumin Lee"
+  },
+  {
+    "id": 13,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 14,
+    "name": " 6 and 1 (In the Mind)",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "Sudhanshu Saria"
+  },
+  {
+    "id": 15,
+    "name": "Faz-me Companhia",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "João Pedro Rodrigues"
+  },
+  {
+    "id": 16,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 17,
+    "name": "Paranormal Activity",
+    "yearReleased": "2007",
+    "language": "English",
+    "director": "Oren Peli"
+  },
+  {
+    "id": 18,
+    "name": "Paranormal Activity 2",
+    "yearReleased": "2010",
+    "language": "English",
+    "director": "Tod Williams"
+  },
+  {
+    "id": 19,
+    "name": "Paranormal Activity 3",
+    "yearReleased": "2011",
+    "language": "English",
+    "director": "Henry joost,Ariel Schulman"
+  },
+  {
+    "id": 20,
+    "name": "Paranormal Activity 4",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "Henry joost,Ariel Schulman"
+  },
+  {
+    "id": 20,
+    "name": "Kanchana",
+    "yearReleased": "2016",
+    "language": "Tamil",
+    "director": "Indian Insan"
+  },
+  {
+    "id": 22,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 23,
+    "name": " Barbarian",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "TZach Cregger"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 20,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 25,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 26,
+    "name": "Videodrome",
+    "yearReleased": "1983",
+    "language": "English",
+    "director": " David Cronenberg"
+  },
+  {
+    "id": 27,
+    "name": " Horror Story",
+    "yearReleased": "2013",
+    "language": "Hindi",
+    "director": "Ayush Raina"
+  },
+  {
+    "id": 28,
+    "name": "The Exorcist",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Andy Newber"
+  },
+  {
+    "id": 29,
+    "name": "The Weird Man",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 30,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 31,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 32,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 33,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 34,
+    "name": "nightmare of the elm street",
+    "yearReleased": "1984",
+    "language": "English",
+    "director": "Wes Craven"
+  },
+  {
+    "id": 35,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {
+    "id": 36,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 37,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "The Unholy",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Evan Spiliotopoulos"
+  },
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 21,
+    "name": "X",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Ti West"
+  },
+  {
+    "id": 22,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 23,
+    "name": "nightmare of the elm street",
+    "yearReleased": "1984",
+    "language": "English",
+    "director": "Wes Craven"
+  },
+  {
+    "id": 24,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 26,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "The Unholy",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Evan Spiliotopoulos"
+  },
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 26,
+    "name": "Alien: Covenant",
+    "yearReleased": " 2017",
+    "language": "English",
+    "director": "Ridley Scott"
+  },
+  {
+    "id": 27,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 21,
+    "name": "Dybbuk",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "Jay Krishnan"
+  },
+  {
+    "id": 28,
+    "name": "House Of Usher",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": "Roger Corman"
+  },
+  {
+    "id": 21,
+    "name": "stree",
+    "yearReleased": "2020",
+    "language": "Hindi",
+    "director": "dev deol"
+  },
+  {
+    "id": 21,
+    "name": "Psycho",
+    "yearReleased": "1960",
+    "language": "English",
+    "director": " Alfred Hitchcock"
+  },
+  {
+    "id": 24,
+    "name": "Dead Silence",
+    "yearReleased": "2007",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 21,
+    "name": "Mahal",
+    "yearReleased": "1949",
+    "language": "Hindi",
+    "director": "Kamal Amrohi"
+  },
+  {
+    "id": 30,
+    "name": "US",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "Jordan Peele"
+  },
+  {
+    "id": 50,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 21,
+    "name": "Annabelle",
+    "yearReleased": "2014",
+    "language": "English",
+    "director": " John R. Leonetti"
+  },
+  {
+    "id": 28,
+    "name": "Midsommar",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": " Ari Aster"
+  },
+  {},
+  {
+    "id": 23,
+    "name": "The Midnigth club",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Mike Flannagan"
+  },
+  {
+    "id": 29,
+    "name": "Orphan",
+    "yearReleased": "2009",
+    "language": "English",
+    "director": "Jaume Collet-Serra"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 22,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Anees Bazmee"
+  },
+  {},
+  {
+    "id": 24,
+    "name": "6-5=2",
+    "yearReleased": "2013",
+    "language": "Kannada",
+    "director": "K S Ashoka"
+  },
+  {
+    "id": 22,
+    "name": "Arundhati",
+    "yearReleased": "2009",
+    "language": "Telugu",
+    "director": "Kodi Ramakrishna"
+  },
+  {
+    "id": 25,
+    "name": "Nope",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "Jordan Peele"
+  },
+  {
+    "id": 32,
+    "name": "Bhool Bhulaiyaa  ",
+    "yearReleased": "2007",
+    "language": "Hindi",
+    "director": "Priyadarshan"
+  },
+  {
+    "id": 32,
+    "name": "stree",
+    "yearReleased": "2019",
+    "language": "Hindi",
+    "director": "Amar Kaushik"
+  },
+  {
+    "id": 27,
+    "name": "sinister",
+    "yearReleased": "2012",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 27,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 28,
+    "name": "Train to Busan",
+    "yearReleased": " 2016",
+    "language": "korean",
+    "director": "Yeon Sang-ho"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 27,
+    "name": "sinister",
+    "yearReleased": "2012",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 27,
+    "name": "1920",
+    "yearReleased": "2008",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 28,
+    "name": "Train to Busan",
+    "yearReleased": " 2016",
+    "language": "korean",
+    "director": "Yeon Sang-ho"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 21,
+    "name": "The Nun",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Corin Hardy"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "shaapit",
+    "yearReleased": "2010",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 21,
+    "name": "Bhool Bhulaiyaa 2",
+    "yearReleased": "2022",
+    "language": "English",
+    "director": "TZach Cregger"
+  },
+  {
+    "id": 20,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 55,
+    "name": "Malignant",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 24,
+    "name": "IT",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Andrés Muschietti"
+  },
+  {
+    "id": 26,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 25,
+    "name": "Bhoot",
+    "yearReleased": "2022",
+    "language": "Hindi",
+    "director": "Bhanu Pratap Singh"
+  },
+  {
+    "id": 21,
+    "name": "Anabella",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "John R. Leonetti"
+  },
+  {
+    "id": 27,
+    "name": "sinister2",
+    "yearReleased": "2015",
+    "language": "english",
+    "director": "scott derrickson"
+  },
+  {
+    "id": 33,
+    "name": "Tumbad",
+    "yearReleased": "2018",
+    "language": "Hindi",
+    "director": "Rahi Barve"
+  },
+  {
+    "id": 99,
+    "name": "kalo",
+    "yearReleased": "1960",
+    "language": "hindi",
+    "director": "pata nahi"
+  },
+  {
+    "id": 27,
+    "name": "Bhootkaal",
+    "yearReleased": "2003",
+    "language": "Hindi",
+    "director": "Ram Gopal Varma"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 56,
+    "name": "Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 29,
+    "name": "Hereditary",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Ari Aster"
+  },
+  {
+    "id": 22,
+    "name": "Roohi",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Hardik Mehta"
+  },
+  {
+    "id": 23,
+    "name": "Stree",
+    "yearReleased": "2018",
+    "language": "English",
+    "director": "Amar Kaushik"
+  },
+  {
+    "id": 26,
+    "name": "Host",
+    "yearReleased": "2020",
+    "language": "English",
+    "director": "Andy dataser"
+  },
+  {
+    "id": 7008,
+    "name": "Handjob Cabin",
+    "yearReleased": "2015",
+    "language": "English",
+    "director": "Bennet Silverman"
+  },
+  {
+    "id": 21,
+    "name": " Chhorii",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Vishal Furia"
+  },
+  {
+    "id": 27,
+    "name": "kanchan",
+    "yearReleased": "2013",
+    "language": "Hindi",
+    "director": "ssr"
+  },
+  {
+    "id": 21,
+    "name": "Host",
+    "yearRealeased": "2020",
+    "language": "English",
+    "director": "Rob Savage"
+  },
+  {
+    "id": 22,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 57,
+    "name": "Aftermath",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": " Peter Winther"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "Corin Hardy"
+  },
+  {
+    "id": 21,
+    "name": "stree",
+    "yearReleased": "2021",
+    "language": "Hindi",
+    "director": "BANSALI"
+  },
+  {
+    "id": 21,
+    "name": "The Shining",
+    "yearReleased": "1980",
+    "language": "English",
+    "director": "Stanley Kubrick"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 57,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "English",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Old",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "M. Night Shyamalan"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 56,
+    "name": "Lights Out ",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "David F. Sandberg"
+  },
+  {
+    "id": 20,
+    "name": "Chhorii",
+    "yearReleased": "2021",
+    "language": "hindi",
+    "director": "Vishal Furia"
+  },
+  {
+    "id": 21,
+    "name": "Veronica",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Paco Plaza"
+  },
+  {
+    "id": 21,
+    "name": "6-5=2",
+    "yearReleased": "2014",
+    "language": "HINDI",
+    "director": "Bharat Jain"
+  },
+  {
+    "id": 22,
+    "name": "brahmastra",
+    "yearReleased": "2022",
+    "language": "HINDI",
+    "director": "Ayan Mukerji"
+  },
+  {
+    "id": 21,
+    "name": "IT'S ALIVE! ",
+    "yearReleased": "1974",
+    "language": "English",
+    "director": "Larry Cohen"
+  },
+  {
+    "id": 28,
+    "name": "The Grudge",
+    "yearReleased": "2004",
+    "language": "Japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 21,
+    "name": "Haunted – 3D",
+    "yearReleased": "2011",
+    "language": "Hindi",
+    "director": "Vikram Bhatt"
+  },
+  {
+    "id": 52,
+    "name": "Alone",
+    "yearReleased": "2015",
+    "language": "Hindi",
+    "director": "Bhushan Patel"
+  },
+  {
+    "id": 53,
+    "name": "vyanki the Dian",
+    "yearReleased": "2022",
+    "language": "Russian",
+    "director": "Vishal chauhan"
+  },
+  {
+    "id": 54,
+    "name": "The Woman in Black",
+    "yearReleased": "2012",
+    "language": "English",
+    "director": "James Watkins"
+  },
+  {
+    "id": 55,
+    "name": "Innocent Curse",
+    "yearReleased": "2017",
+    "language": "japanese",
+    "director": "Takashi Shimizu"
+  },
+  {
+    "id": 79,
+    "name": "The Ring",
+    "yearReleased": "2003",
+    "language": "English",
+    "director": "Gore Verbinski"
+  },
+  {
+    "id": 22,
+    "name": "The Conjuring 2",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 23,
+    "name": "Resident Evil",
+    "yearReleased": "2002",
+    "language": "English",
+    "director": "Paul W.S. Anderson"
+  },
+  {
+    "id": 21,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "John boorman"
+  },
+  {
+    "id": 29,
+    "name": "The Conjuring",
+    "yearReleased": "2013",
+    "language": "English",
+    "director": "James Wan"
+  },
+  {
+    "id": 23,
+    "name": "IT",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Andy Muschietti"
+  },
+  {
+    "id": 24,
+    "name": "Get Out",
+    "yearReleased": "2017",
+    "language": "English",
+    "director": "Jordan Peele"
+  },
+  {
+    "id": 25,
+    "name": "The Exorcism of Emily Rose",
+    "yearReleased": "2005 ",
+    "language": "English",
+    "director": "Scott Derrickson"
+  },
+  {
+    "id": 26,
+    "name": "The Unholy",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Evan Spiliotopoulos"
+  },
+  {
+    "id": 333,
+    "name": "Pontypool",
+    "yearReleased": "2008",
+    "language": "English",
+    "director": "Bruce McDonald"
+  },
+  {
+    "id": 25,
+    "name": "The Exorcism of Emily Rose",
+    "yearReleased": "2005 ",
+    "language": "English",
+    "director": "Scott Derrickson"
+  },
+  {
+    "id": 26,
+    "name": "The Unholy",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Evan Spiliotopoulos"
+  },
+  {
+    "id": 27,
+    "name": "10 Cloverfield Lane",
+    "yearReleased": "2016",
+    "language": "English",
+    "director": "Dan Trachtenberg"
+  },
+  {
+    "id": 27,
+    "name": "Martyyrs",
+    "yearReleased": "2008",
+    "language": "French",
+    "director": "Pascal Laugier"
+  },
+  {
+    "id": 55,
+    "name": "Kanchana",
+    "yearReleased": "2017",
+    "language": "hindi",
+    "director": "P.Vas Shivalinga"
+  },
+  {
+    "id": 28,
+    "name": "Bhootiya",
+    "yearReleased": "2020",
+    "language": "Hindi",
+    "director": "Vishal Dadlanni"
+  },
+  {
+    "id": 100,
+    "name": "Wrong Turn",
+    "yearReleased": "2021",
+    "language": "English",
+    "director": "Mike P. Nelson"
+  },
+  {
+    "id": 102,
+    "name": "Chhorii",
+    "yearReleased": "2021",
+    "language": "hindi",
+    "director": "Vishal Furia"
+  },
+  {
+    "id": 101,
+    "name": "The Exorcist",
+    "yearReleased": "1973",
+    "language": "English",
+    "director": "William Friedkin"
+  },
+  {
+    "id": 114,
+    "name": "The Amityville Horror",
+    "yearReleased": "1979",
+    "language": "English",
+    "director": "Stuart Rosenberg"
+  },
+  {
+    "id": 201,
+    "name": "Avatar",
+    "yearReleased": "2009",
+    "language": "English",
+    "director": "James Cameron"
+  },
+  {
+    "id": 152,
+    "name": "13B: Fear Has a New Address",
+    "yearReleased": "2009",
+    "language": "Hindi",
+    "director": "Vikram Kumar"
+  },
+  {
+    "id": 673,
+    "name": "A Serbian Film",
+    "yearReleased": "2010",
+    "language": "Serbian, English, Swedish",
+    "director": "Srdjan Spasojevic"
+  },
+  {
+    "id": 674,
+    "name": "8: A South African Horror Story",
+    "yearReleased": "2019",
+    "language": "English",
+    "director": "Harold Holscher"
+  }
 ]

--- a/data.json
+++ b/data.json
@@ -1,1135 +1,1133 @@
 [
-      {
-          "id": 1,
-          "name": "Host",
-          "yearReleased": "2020",
-          "language": "English",
-          "director": "Andy dataser"
-      },
-    
-      {
-          "id": 3,
-          "name": "The Ring",
-          "yearReleased": "2004",
-          "language": "English",
-          "director": "Andy Newsir"
-      },
-      {
-          "id": 4,
-          "name": "Dahmer",
-          "yearReleased": "2002",
-          "language": "English",
-          "director": "David Jacobson"
-      },
-      {
-          "id": 5,
-          "name": "The Conjuring",
-          "yearReleased": "2013",
-          "language": "English",
-          "director": "James Wan"
-      },
-      {
-          "id": 6,
-          "name": "one missed call",
-          "yearReleased": "2008",
-          "language": "English",
-          "director": "Eric Vallete"
-      },
-      {
-          "id": 7,
-          "name": "The Midnigth club",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "Mike Flannagan"
-      },
-      {
-          "id": 8,
-          "name": "Insidious",
-          "yearReleased": "2010",
-          "language": "English",
-          "director": "James Wan"
-      },
-      {
-          "id": 9,
-          "name": "Veronica",
-          "yearReleased": "2017",
-          "language": "English",
-          "director": "plazo"
-      },
-      {
-          "id": 10,
-          "name": "Lights Out ",
-          "yearReleased": "2016",
-          "language": "English",
-          "director": "David F. Sandberg"
-      },
-      {
-          "id": 11,
-          "name": "Veronica",
-          "yearReleased": "2017",
-          "language": "English",
-          "director": "paco plazo"
-      },
-      {
-          "id": 12,
-          "name": " The Omen in Devil Town ",
-          "yearReleased": "1993",
-          "language": "English",
-          "director": "Qumin Lee"
-      },
-      {
-          "id": 13,
-          "name": "Bhootkaal",
-          "yearReleased": "2003",
-          "language": "Hindi",
-          "director": "Ram Gopal Varma"
-      },
-      {
-          "id": 14,
-          "name": " 6 and 1 (In the Mind)",
-          "yearReleased": "2019",
-          "language": "English",
-          "director": "Sudhanshu Saria"
-      },
-      {
-          "id": 15,
-          "name": "Faz-me Companhia",
-          "yearReleased": "2019",
-          "language": "English",
-          "director": "João Pedro Rodrigues"
-      },
-      {
-          "id": 16,
-          "name": "The Conjuring",
-          "yearReleased": "2013",
-          "language": "English",
-          "director": "James Wan"
-      },
-      {
-          "id": 17,
-          "name": "Paranormal Activity",
-          "yearReleased": "2007",
-          "language": "English",
-          "director": "Oren Peli"
-      },
-      {
-          "id": 18,
-          "name": "Paranormal Activity 2",
-          "yearReleased": "2010",
-          "language": "English",
-          "director": "Tod Williams"
-      },
-      {
-          "id": 19,
-          "name": "Paranormal Activity 3",
-          "yearReleased": "2011",
-          "language": "English",
-          "director": "Henry joost,Ariel Schulman"
-      },
-      {
-          "id": 20,
-          "name": "Paranormal Activity 4",
-          "yearReleased": "2012",
-          "language": "English",
-          "director": "Henry joost,Ariel Schulman"
-      },
-      {
-          "id": 20,
-          "name": "Kanchana",
-          "yearReleased": "2016",
-          "language": "Tamil",
-          "director": "Indian Insan"
-      },
-      {
-          "id": 22,
-          "name": "X",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "Ti West"
-      },
-      {
-          "id": 23,
-          "name": " Barbarian",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "TZach Cregger"
-      },
-      {
-          "id": 21,
-          "name": "The Exorcist",
-          "yearReleased": "1973",
-          "language": "English",
-          "director": "William Friedkin"
-      },
-      {
-          "id": 20,
-          "name": "Wrong Turn",
-          "yearReleased": "2021",
-          "language": "English",
-          "director": "Mike P. Nelson"
-      },
-      {
-          "id": 25,
-          "name": "Wrong Turn",
-          "yearReleased": "2021",
-          "language": "English",
-          "director": "Mike P. Nelson"
-      },
-      {
-          "id": 26,
-          "name": "Videodrome",
-          "yearReleased": "1983",
-          "language": "English",
-          "director": " David Cronenberg"
-      },
-      {
-          "id": 27,
-          "name": " Horror Story",
-          "yearReleased": "2013",
-          "language": "Hindi",
-          "director": "Ayush Raina"
-      },
-      {
-          "id": 28,
-          "name": "The Exorcist",
-          "yearReleased": "2018",
-          "language": "English",
-          "director": "Andy Newber"
-      },
-      {
-          "id": 29,
-          "name": "The Weird Man",
-          "yearReleased": "2021",
-          "language": "English",
-          "director": "Mike P. Nelson"
-      },
-      {
-          "id": 30,
-          "name": "Psycho",
-          "yearReleased": "1960",
-          "language": "English",
-          "director": " Alfred Hitchcock"
-      },
-      {
-          "id": 31,
-          "name": "Psycho",
-          "yearReleased": "1960",
-          "language": "English",
-          "director": " Alfred Hitchcock"
-      },
-      {
-          "id": 21,
-          "name": "Psycho",
-          "yearReleased": "1960",
-          "language": "English",
-          "director": " Alfred Hitchcock"
-      },
-      {
-          "id": 32,
-          "name": "X",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "Ti West"
-      },
-      {
-          "id": 33,
-          "name": "Annabelle",
-          "yearReleased": "2014",
-          "language": "English",
-          "director": " John R. Leonetti"
-      },
-      {
-          "id": 34,
-          "name": "nightmare of the elm street",
-          "yearReleased": "1984",
-          "language": "English",
-          "director": "Wes Craven"
-      },
-      {
-          "id": 35,
-          "name": "Bhool Bhulaiyaa 2",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "Anees Bazmee"
-      },
-      {
-          "id": 36,
-          "name": "Bhoot",
-          "yearReleased": "2022",
-          "language": "Hindi",
-          "director": "Bhanu Pratap Singh"
-      },
-      {
-          "id": 37,
-          "name": "Alien: Covenant",
-          "yearReleased": " 2017",
-          "language": "English",
-          "director": "Ridley Scott"
-      },
-      {
-          "id": 27,
-          "name": "6-5=2",
-          "yearReleased": "2013",
-          "language": "Kannada",
-          "director": "K S Ashoka"
-      },
-      {
-          "id": 21,
-          "name": "Dybbuk",
-          "yearReleased": "2021",
-          "language": "Hindi",
-          "director": "Jay Krishnan"
-      },
-      {
-          "id": 28,
-          "name": "House Of Usher",
-          "yearReleased": "1960",
-          "language": "English",
-          "director": "Roger Corman"
-      },
-      {
-          "id": 21,
-          "name": "The Unholy",
-          "yearReleased": "2021",
-          "language": "English",
-          "director": "Evan Spiliotopoulos"
-      },
-      {
-          "id": 23,
-          "name": "The Midnigth club",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "Mike Flannagan"
-      },
-      {
-          "id": 21,
-          "name": "Psycho",
-          "yearReleased": "1960",
-          "language": "English",
-          "director": " Alfred Hitchcock"
-      },
-      {
-          "id": 21,
-          "name": "X",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "Ti West"
-      },
-      {
-          "id": 22,
-          "name": "Annabelle",
-          "yearReleased": "2014",
-          "language": "English",
-          "director": " John R. Leonetti"
-      },
-      {
-          "id": 23,
-          "name": "nightmare of the elm street",
-          "yearReleased": "1984",
-          "language": "English",
-          "director": "Wes Craven"
-      },
-      {
-          "id": 24,
-          "name": "Bhool Bhulaiyaa 2",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "Anees Bazmee"
-      },
-      {
-          "id": 25,
-          "name": "Bhoot",
-          "yearReleased": "2022",
-          "language": "Hindi",
-          "director": "Bhanu Pratap Singh"
-      },
-      {
-          "id": 26,
-          "name": "Alien: Covenant",
-          "yearReleased": " 2017",
-          "language": "English",
-          "director": "Ridley Scott"
-      },
-      {
-          "id": 27,
-          "name": "6-5=2",
-          "yearReleased": "2013",
-          "language": "Kannada",
-          "director": "K S Ashoka"
-      },
-      {
-          "id": 21,
-          "name": "Dybbuk",
-          "yearReleased": "2021",
-          "language": "Hindi",
-          "director": "Jay Krishnan"
-      },
-      {
-          "id": 28,
-          "name": "House Of Usher",
-          "yearReleased": "1960",
-          "language": "English",
-          "director": "Roger Corman"
-      },
-      {
-          "id": 21,
-          "name": "The Unholy",
-          "yearReleased": "2021",
-          "language": "English",
-          "director": "Evan Spiliotopoulos"
-      },
-      {
-          "id": 23,
-          "name": "The Midnigth club",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "Mike Flannagan"
-      },
-      {
-          "id": 25,
-          "name": "Bhoot",
-          "yearReleased": "2022",
-          "language": "Hindi",
-          "director": "Bhanu Pratap Singh"
-      },
-      {
-          "id": 26,
-          "name": "Alien: Covenant",
-          "yearReleased": " 2017",
-          "language": "English",
-          "director": "Ridley Scott"
-      },
-      {
-          "id": 27,
-          "name": "6-5=2",
-          "yearReleased": "2013",
-          "language": "Kannada",
-          "director": "K S Ashoka"
-      },
-      {
-          "id": 21,
-          "name": "Dybbuk",
-          "yearReleased": "2021",
-          "language": "Hindi",
-          "director": "Jay Krishnan"
-      },
-      {
-          "id": 28,
-          "name": "House Of Usher",
-          "yearReleased": "1960",
-          "language": "English",
-          "director": "Roger Corman"
-      },
-      {
-          "id": 21,
-          "name": "stree",
-          "yearReleased": "2020",
-          "language": "Hindi",
-          "director": "dev deol"
-      },
-      {
-          "id": 21,
-          "name": "Psycho",
-          "yearReleased": "1960",
-          "language": "English",
-          "director": " Alfred Hitchcock"
-      },
-      {
-          "id": 24,
-          "name": "Dead Silence",
-          "yearReleased": "2007",
-          "language": "English",
-          "director": "James Wan"
-      },
-      {
-          "id": 21,
-          "name": "Mahal",
-          "yearReleased": "1949",
-          "language": "Hindi",
-          "director": "Kamal Amrohi"
-      },
-      {
-          "id": 30,
-          "name": "US",
-          "yearReleased": "2019",
-          "language": "English",
-          "director": "Jordan Peele"
-      },
-      {
-          "id": 50,
-          "name": "1920",
-          "yearReleased": "2008",
-          "language": "Hindi",
-          "director": "Vikram Bhatt"
-      },
-      {
-          "id": 21,
-          "name": "Annabelle",
-          "yearReleased": "2014",
-          "language": "English",
-          "director": " John R. Leonetti"
-      },
-      {
-          "id": 28,
-          "name": "Midsommar",
-          "yearReleased": "2019",
-          "language": "English",
-          "director": " Ari Aster"
-      },
-      {},
-      {
-          "id": 23,
-          "name": "The Midnigth club",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "Mike Flannagan"
-      },
-      {
-          "id": 29,
-          "name": "Orphan",
-          "yearReleased": "2009",
-          "language": "English",
-          "director": "Jaume Collet-Serra"
-      },
-      {
-          "id": 21,
-          "name": "The Exorcist",
-          "yearReleased": "1973",
-          "language": "English",
-          "director": "William Friedkin"
-      },
-      {
-          "id": 22,
-          "name": "Bhool Bhulaiyaa 2",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "Anees Bazmee"
-      },
-      {},
-      {
-          "id": 24,
-          "name": "6-5=2",
-          "yearReleased": "2013",
-          "language": "Kannada",
-          "director": "K S Ashoka"
-      },
-      {
-          "id": 22,
-          "name": "Arundhati",
-          "yearReleased": "2009",
-          "language": "Telugu",
-          "director": "Kodi Ramakrishna"
-      },
-      {
-          "id": 25,
-          "name": "Nope",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "Jordan Peele"
-      },
-      {
-          "id": 32,
-          "name": "Bhool Bhulaiyaa  ",
-          "yearReleased": "2007",
-          "language": "Hindi",
-          "director": "Priyadarshan"
-      },
-      {
-          "id": 32,
-          "name": "stree",
-          "yearReleased": "2019",
-          "language": "Hindi",
-          "director": "Amar Kaushik"
-      },
-      {
-          "id": 27,
-          "name": "sinister",
-          "yearReleased": "2012",
-          "language": "english",
-          "director": "scott derrickson"
-      },
-      {
-          "id": 27,
-          "name": "1920",
-          "yearReleased": "2008",
-          "language": "Hindi",
-          "director": "Vikram Bhatt"
-      },
-      {
-          "id": 28,
-          "name": "Train to Busan",
-          "yearReleased": " 2016",
-          "language": "korean",
-          "director": "Yeon Sang-ho"
-      },
-      {
-          "id": 27,
-          "name": "sinister2",
-          "yearReleased": "2015",
-          "language": "english",
-          "director": "scott derrickson"
-      },
-      {
-          "id": 33,
-          "name": "Tumbad",
-          "yearReleased": "2018",
-          "language": "Hindi",
-          "director": "Rahi Barve"
-      },
-      {
-          "id": 99,
-          "name": "kalo",
-          "yearReleased": "1960",
-          "language": "hindi",
-          "director": "pata nahi"
-      },
-      {
-          "id": 27,
-          "name": "Bhootkaal",
-          "yearReleased": "2003",
-          "language": "Hindi",
-          "director": "Ram Gopal Varma"
-      },
-      {
-          "id": 52,
-          "name": "Alone",
-          "yearReleased": "2015",
-          "language": "Hindi",
-          "director": "Bhushan Patel"
-      },
-      {
-          "id": 53,
-          "name": "vyanki the Dian",
-          "yearReleased": "2022",
-          "language": "Russian",
-          "director": "Vishal chauhan"
-      },
-      {
-          "id": 27,
-          "name": "sinister",
-          "yearReleased": "2012",
-          "language": "english",
-          "director": "scott derrickson"
-      },
-      {
-          "id": 27,
-          "name": "1920",
-          "yearReleased": "2008",
-          "language": "Hindi",
-          "director": "Vikram Bhatt"
-      },
-      {
-          "id": 28,
-          "name": "Train to Busan",
-          "yearReleased": " 2016",
-          "language": "korean",
-          "director": "Yeon Sang-ho"
-      },
-      {
-          "id": 27,
-          "name": "sinister2",
-          "yearReleased": "2015",
-          "language": "english",
-          "director": "scott derrickson"
-      },
-      {
-          "id": 21,
-          "name": "The Nun",
-          "yearReleased": "2018",
-          "language": "English",
-          "director": "Corin Hardy"
-      },
-      {
-          "id": 33,
-          "name": "Tumbad",
-          "yearReleased": "2018",
-          "language": "Hindi",
-          "director": "Rahi Barve"
-      },
-      {
-          "id": 99,
-          "name": "kalo",
-          "yearReleased": "1960",
-          "language": "hindi",
-          "director": "pata nahi"
-      },
-      {
-          "id": 52,
-          "name": "Alone",
-          "yearReleased": "2015",
-          "language": "Hindi",
-          "director": "Bhushan Patel"
-      },
-      {
-          "id": 53,
-          "name": "vyanki the Dian",
-          "yearReleased": "2022",
-          "language": "Russian",
-          "director": "Vishal chauhan"
-      },
-      {
-          "id": 54,
-          "name": "shaapit",
-          "yearReleased": "2010",
-          "language": "Hindi",
-          "director": "Vikram Bhatt"
-      },
-      {
-          "id": 27,
-          "name": "Bhootkaal",
-          "yearReleased": "2003",
-          "language": "Hindi",
-          "director": "Ram Gopal Varma"
-      },
-      {
-          "id": 21,
-          "name": "Bhool Bhulaiyaa 2",
-          "yearReleased": "2022",
-          "language": "English",
-          "director": "TZach Cregger"
-      },
-      {
-          "id": 20,
-          "name": "Wrong Turn",
-          "yearReleased": "2021",
-          "language": "English",
-          "director": "Mike P. Nelson"
-      },
-      {
-          "id": 55,
-          "name": "Malignant",
-          "yearReleased": "2021",
-          "language": "English",
-          "director": "James Wan"
-      },
-      {
-          "id": 24,
-          "name": "IT",
-          "yearReleased": "2017",
-          "language": "English",
-          "director": "Andrés Muschietti"
-      },
-      {
-          "id": 26,
-          "name": "Host",
-          "yearReleased": "2020",
-          "language": "English",
-          "director": "Andy dataser"
-      },
-      {
-          "id": 25,
-          "name": "Bhoot",
-          "yearReleased": "2022",
-          "language": "Hindi",
-          "director": "Bhanu Pratap Singh"
-      },
-      {
-          "id": 21,
-          "name": "Anabella",
-          "yearReleased": "2017",
-          "language": "English",
-          "director": "John R. Leonetti"
-      },
-      {
-          "id": 27,
-          "name": "sinister2",
-          "yearReleased": "2015",
-          "language": "english",
-          "director": "scott derrickson"
-      },
-      {
-          "id": 33,
-          "name": "Tumbad",
-          "yearReleased": "2018",
-          "language": "Hindi",
-          "director": "Rahi Barve"
-      },
-      {
-          "id": 99,
-          "name": "kalo",
-          "yearReleased": "1960",
-          "language": "hindi",
-          "director": "pata nahi"
-      },
-      {
-          "id": 27,
-          "name": "Bhootkaal",
-          "yearReleased": "2003",
-          "language": "Hindi",
-          "director": "Ram Gopal Varma"
-      },
-      {
-          "id": 52,
-          "name": "Alone",
-          "yearReleased": "2015",
-          "language": "Hindi",
-          "director": "Bhushan Patel"
-      },
-      {
-          "id": 53,
-          "name": "vyanki the Dian",
-          "yearReleased": "2022",
-          "language": "Russian",
-          "director": "Vishal chauhan"
-      },
-      {
-          "id": 56,
-          "name": "Conjuring",
-          "yearReleased": "2013",
-          "language": "English",
-          "director": "James Wan"
-      },
-      {
-          "id": 29,
-          "name": "Hereditary",
-          "yearReleased": "2018",
-          "language": "English",
-          "director": "Ari Aster"
-      },
-      {
-          "id": 22,
-          "name": "Roohi",
-          "yearReleased": "2021",
-          "language": "English",
-          "director": "Hardik Mehta"
-      },
-      {
-          "id": 23,
-          "name": "Stree",
-          "yearReleased": "2018",
-          "language": "English",
-          "director": "Amar Kaushik"
-      },
-      {
-          "id": 26,
-          "name": "Host",
-          "yearReleased": "2020",
-          "language": "English",
-          "director": "Andy dataser"
-      },
-      {
-          "id": 7008,
-          "name": "Handjob Cabin",
-          "yearReleased": "2015",
-          "language": "English",
-          "director": "Bennet Silverman"
-      },
-      {
-          "id": 21,
-          "name": " Chhorii",
-          "yearReleased": "2017",
-          "language": "English",
-          "director": "Vishal Furia"
-      },
-      {
-          "id": 27,
-          "name": "kanchan",
-          "yearReleased": "2013",
-          "language": "Hindi",
-          "director": "ssr"
-      },
-      {
-          "id": 21,
-          "name": "Host",
-          "yearRealeased": "2020",
-          "language": "English",
-          "director": "Rob Savage"
-      },
-      {
-          "id": 22,
-          "name": "The Exorcist",
-          "yearReleased": "1973",
-          "language": "English",
-          "director": "William Friedkin"
-      },
-      {
-          "id": 52,
-          "name": "Alone",
-          "yearReleased": "2015",
-          "language": "Hindi",
-          "director": "Bhushan Patel"
-      },
-      {
-          "id": 53,
-          "name": "vyanki the Dian",
-          "yearReleased": "2022",
-          "language": "Russian",
-          "director": "Vishal chauhan"
-      },
-      {
-          "id": 54,
-          "name": "The Woman in Black",
-          "yearReleased": "2012",
-          "language": "English",
-          "director": "James Watkins"
-      },
-      {
-          "id": 55,
-          "name": "Innocent Curse",
-          "yearReleased": "2017",
-          "language": "japanese",
-          "director": "Takashi Shimizu"
-      },
-      {
-          "id": 52,
-          "name": "Alone",
-          "yearReleased": "2015",
-          "language": "Hindi",
-          "director": "Bhushan Patel"
-      },
-      {
-          "id": 53,
-          "name": "vyanki the Dian",
-          "yearReleased": "2022",
-          "language": "Russian",
-          "director": "Vishal chauhan"
-      },
-      {
-          "id": 54,
-          "name": "The Woman in Black",
-          "yearReleased": "2012",
-          "language": "English",
-          "director": "Corin Hardy"
-      },
-      {
-          "id": 21,
-          "name": "stree",
-          "yearReleased": "2021",
-          "language": "Hindi",
-          "director": "BANSALI"
-      },
-      {
-          "id": 21,
-          "name": "The Shining",
-          "yearReleased": "1980",
-          "language": "English",
-          "director": "Stanley Kubrick"
-      },
-      {
-          "id": 52,
-          "name": "Alone",
-          "yearReleased": "2015",
-          "language": "Hindi",
-          "director": "Bhushan Patel"
-      },
-      {
-          "id": 53,
-          "name": "vyanki the Dian",
-          "yearReleased": "2022",
-          "language": "Russian",
-          "director": "Vishal chauhan"
-      },
-      {
-          "id": 54,
-          "name": "The Woman in Black",
-          "yearReleased": "2012",
-          "language": "English",
-          "director": "James Watkins"
-      },
-      {
-          "id": 52,
-          "name": "Alone",
-          "yearReleased": "2015",
-          "language": "Hindi",
-          "director": "Bhushan Patel"
-      },
-      {
-          "id": 53,
-          "name": "vyanki the Dian",
-          "yearReleased": "2022",
-          "language": "Russian",
-          "director": "Vishal chauhan"
-      },
-      {
-          "id": 54,
-          "name": "The Woman in Black",
-          "yearReleased": "2012",
-          "language": "English",
-          "director": "James Watkins"
-      },
-      {
-          "id": 55,
-          "name": "Innocent Curse",
-          "yearReleased": "2017",
-          "language": "japanese",
-          "director": "Takashi Shimizu"
-      },
-      {
-          "id": 56,
-          "name": "Lights Out ",
-          "yearReleased": "2016",
-          "language": "English",
-          "director": "David F. Sandberg"
-      },
-      {
-          "id": 57,
-          "name": "Alone",
-          "yearReleased": "2015",
-          "language": "English",
-          "director": "Bhushan Patel"
-      },
-      {
-          "id": 55,
-          "name": "Innocent Curse",
-          "yearReleased": "2017",
-          "language": "japanese",
-          "director": "Takashi Shimizu"
-      },
-      {
-          "id": 56,
-          "name": "Old",
-          "yearReleased": "2021",
-          "language": "English",
-          "director": "M. Night Shyamalan"
-      },
-      {
-          "id": 55,
-          "name": "Innocent Curse",
-          "yearReleased": "2017",
-          "language": "japanese",
-          "director": "Takashi Shimizu"
-      },
-      {
-          "id": 56,
-          "name": "Lights Out ",
-          "yearReleased": "2016",
-          "language": "English",
-          "director": "David F. Sandberg"
-      },
-      {
-          "id": 20,
-          "name": "Chhorii",
-          "yearReleased": "2021",
-          "language": "hindi",
-          "director": "Vishal Furia"
-      },
-      {
-          "id": 21,
-          "name": "Veronica",
-          "yearReleased": "2017",
-          "language": "English",
-          "director": "Paco Plaza"
-      },
-      {
-          "id": 21,
-          "name": "6-5=2",
-          "yearReleased": "2014",
-          "language": "HINDI",
-          "director": "Bharat Jain"
-      },
-      {
-          "id": 22,
-          "name": "brahmastra",
-          "yearReleased": "2022",
-          "language": "HINDI",
-          "director": "Ayan Mukerji"
-      },
-      {
-          "id": 21,
-          "name": "IT'S ALIVE! ",
-          "yearReleased": "1974",
-          "language": "English",
-          "director": "Larry Cohen"
-      },
-      {
-          "id": 28,
-          "name": "The Grudge",
-          "yearReleased": "2004",
-          "language": "Japanese",
-          "director": "Takashi Shimizu"
-      },
-      {
-          "id": 21,
-          "name": "Haunted – 3D",
-          "yearReleased": "2011",
-          "language": "Hindi",
-          "director": "Vikram Bhatt"
-      },
-      {
-          "id": 52,
-          "name": "Alone",
-          "yearReleased": "2015",
-          "language": "Hindi",
-          "director": "Bhushan Patel"
-      },
-      {
-          "id": 53,
-          "name": "vyanki the Dian",
-          "yearReleased": "2022",
-          "language": "Russian",
-          "director": "Vishal chauhan"
-      },
-      {
-          "id": 54,
-          "name": "The Woman in Black",
-          "yearReleased": "2012",
-          "language": "English",
-          "director": "James Watkins"
-      },
-      {
-          "id": 55,
-          "name": "Innocent Curse",
-          "yearReleased": "2017",
-          "language": "japanese",
-          "director": "Takashi Shimizu"
-      },
-      {
-          "id": 79,
-          "name": "The Ring",
-          "yearReleased": "2003",
-          "language": "English",
-          "director": "Gore Verbinski"
-      },
-      {
-          "id": 22,
-          "name": "The Conjuring 2",
-          "yearReleased": "2016",
-          "language": "English",
-          "director": "James Wan"
-      },
-      {
-          "id": 23,
-          "name": "Resident Evil",
-          "yearReleased": "2002",
-          "language": "English",
-          "director": "Paul W.S. Anderson"
-      },
-      {
-          "id": 21,
-          "name": "The Exorcist",
-          "yearReleased": "1973",
-          "language": "English",
-          "director": "John boorman"
-      },
-      {
-          "id": 29,
-          "name": "The Conjuring",
-          "yearReleased": "2013",
-          "language": "English",
-          "director": "James Wan"
-      },
-      {
-          "id": 23,
-          "name": "IT",
-          "yearReleased": "2017",
-          "language": "English",
-          "director": "Andy Muschietti"
-      },
-      {
-          "id": 24,
-          "name": "Get Out",
-          "yearReleased": "2017",
-          "language": "English",
-          "director": "Jordan Peele"
-      }
-      ,
-      {
-          "id": 231,
-          "name": "Halloween Kills",
-          "yearReleased": "2021",
-          "language": "English",
-          "director": "David Gordon Green"
-      },
+    {
+        "id": 1,
+        "name": "Host",
+        "yearReleased": "2020",
+        "language": "English",
+        "director": "Andy dataser"
+    },
+    {
+        "id": 3,
+        "name": "The Ring",
+        "yearReleased": "2004",
+        "language": "English",
+        "director": "Andy Newsir"
+    },
+    {
+        "id": 4,
+        "name": "Dahmer",
+        "yearReleased": "2002",
+        "language": "English",
+        "director": "David Jacobson"
+    },
+    {
+        "id": 5,
+        "name": "The Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 6,
+        "name": "One Missed Call",
+        "yearReleased": "2008",
+        "language": "English",
+        "director": "Eric Vallete"
+    },
+    {
+        "id": 7,
+        "name": "The Midnigth Club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 8,
+        "name": "Insidious",
+        "yearReleased": "2010",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 9,
+        "name": "Veronica",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "plazo"
+    },
+    {
+        "id": 10,
+        "name": "Lights Out ",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "David F. Sandberg"
+    },
+    {
+        "id": 11,
+        "name": "Veronica",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "paco plazo"
+    },
+    {
+        "id": 12,
+        "name": " The Omen in Devil Town ",
+        "yearReleased": "1993",
+        "language": "English",
+        "director": "Qumin Lee"
+    },
+    {
+        "id": 13,
+        "name": "Bhootkaal",
+        "yearReleased": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 14,
+        "name": " 6 and 1 (In the Mind)",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": "Sudhanshu Saria"
+    },
+    {
+        "id": 15,
+        "name": "Faz-me Companhia",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": "João Pedro Rodrigues"
+    },
+    {
+        "id": 16,
+        "name": "The Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 17,
+        "name": "Paranormal Activity",
+        "yearReleased": "2007",
+        "language": "English",
+        "director": "Oren Peli"
+    },
+    {
+        "id": 18,
+        "name": "Paranormal Activity 2",
+        "yearReleased": "2010",
+        "language": "English",
+        "director": "Tod Williams"
+    },
+    {
+        "id": 19,
+        "name": "Paranormal Activity 3",
+        "yearReleased": "2011",
+        "language": "English",
+        "director": "Henry joost,Ariel Schulman"
+    },
+    {
+        "id": 20,
+        "name": "Paranormal Activity 4",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "Henry joost,Ariel Schulman"
+    },
+    {
+        "id": 20,
+        "name": "Kanchana",
+        "yearReleased": "2016",
+        "language": "Tamil",
+        "director": "Indian Insan"
+    },
+    {
+        "id": 22,
+        "name": "X",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Ti West"
+    },
+    {
+        "id": 23,
+        "name": " Barbarian",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "TZach Cregger"
+    },
+    {
+        "id": 21,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "William Friedkin"
+    },
+    {
+        "id": 20,
+        "name": "Wrong Turn",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 25,
+        "name": "Wrong Turn",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 26,
+        "name": "Videodrome",
+        "yearReleased": "1983",
+        "language": "English",
+        "director": " David Cronenberg"
+    },
+    {
+        "id": 27,
+        "name": " Horror Story",
+        "yearReleased": "2013",
+        "language": "Hindi",
+        "director": "Ayush Raina"
+    },
+    {
+        "id": 28,
+        "name": "The Exorcist",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Andy Newber"
+    },
+    {
+        "id": 29,
+        "name": "The Weird Man",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 30,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 31,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 21,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 32,
+        "name": "X",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Ti West"
+    },
+    {
+        "id": 33,
+        "name": "Annabelle",
+        "yearReleased": "2014",
+        "language": "English",
+        "director": " John R. Leonetti"
+    },
+    {
+        "id": 34,
+        "name": "nightmare of the elm street",
+        "yearReleased": "1984",
+        "language": "English",
+        "director": "Wes Craven"
+    },
+    {
+        "id": 35,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Anees Bazmee"
+    },
+    {
+        "id": 36,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 37,
+        "name": "Alien: Covenant",
+        "yearReleased": " 2017",
+        "language": "English",
+        "director": "Ridley Scott"
+    },
+    {
+        "id": 27,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 21,
+        "name": "Dybbuk",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "Jay Krishnan"
+    },
+    {
+        "id": 28,
+        "name": "House Of Usher",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": "Roger Corman"
+    },
+    {
+        "id": 21,
+        "name": "The Unholy",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Evan Spiliotopoulos"
+    },
+    {
+        "id": 23,
+        "name": "The Midnigth club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 21,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 21,
+        "name": "X",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Ti West"
+    },
+    {
+        "id": 22,
+        "name": "Annabelle",
+        "yearReleased": "2014",
+        "language": "English",
+        "director": " John R. Leonetti"
+    },
+    {
+        "id": 23,
+        "name": "nightmare of the elm street",
+        "yearReleased": "1984",
+        "language": "English",
+        "director": "Wes Craven"
+    },
+    {
+        "id": 24,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Anees Bazmee"
+    },
+    {
+        "id": 25,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 26,
+        "name": "Alien: Covenant",
+        "yearReleased": " 2017",
+        "language": "English",
+        "director": "Ridley Scott"
+    },
+    {
+        "id": 27,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 21,
+        "name": "Dybbuk",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "Jay Krishnan"
+    },
+    {
+        "id": 28,
+        "name": "House Of Usher",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": "Roger Corman"
+    },
+    {
+        "id": 21,
+        "name": "The Unholy",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Evan Spiliotopoulos"
+    },
+    {
+        "id": 23,
+        "name": "The Midnigth club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 25,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 26,
+        "name": "Alien: Covenant",
+        "yearReleased": " 2017",
+        "language": "English",
+        "director": "Ridley Scott"
+    },
+    {
+        "id": 27,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 21,
+        "name": "Dybbuk",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "Jay Krishnan"
+    },
+    {
+        "id": 28,
+        "name": "House Of Usher",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": "Roger Corman"
+    },
+    {
+        "id": 21,
+        "name": "stree",
+        "yearReleased": "2020",
+        "language": "Hindi",
+        "director": "dev deol"
+    },
+    {
+        "id": 21,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 24,
+        "name": "Dead Silence",
+        "yearReleased": "2007",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 21,
+        "name": "Mahal",
+        "yearReleased": "1949",
+        "language": "Hindi",
+        "director": "Kamal Amrohi"
+    },
+    {
+        "id": 30,
+        "name": "US",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": "Jordan Peele"
+    },
+    {
+        "id": 50,
+        "name": "1920",
+        "yearReleased": "2008",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 21,
+        "name": "Annabelle",
+        "yearReleased": "2014",
+        "language": "English",
+        "director": " John R. Leonetti"
+    },
+    {
+        "id": 28,
+        "name": "Midsommar",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": " Ari Aster"
+    },
+    {},
+    {
+        "id": 23,
+        "name": "The Midnigth club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 29,
+        "name": "Orphan",
+        "yearReleased": "2009",
+        "language": "English",
+        "director": "Jaume Collet-Serra"
+    },
+    {
+        "id": 21,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "William Friedkin"
+    },
+    {
+        "id": 22,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Anees Bazmee"
+    },
+    {},
+    {
+        "id": 24,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 22,
+        "name": "Arundhati",
+        "yearReleased": "2009",
+        "language": "Telugu",
+        "director": "Kodi Ramakrishna"
+    },
+    {
+        "id": 25,
+        "name": "Nope",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Jordan Peele"
+    },
+    {
+        "id": 32,
+        "name": "Bhool Bhulaiyaa  ",
+        "yearReleased": "2007",
+        "language": "Hindi",
+        "director": "Priyadarshan"
+    },
+    {
+        "id": 32,
+        "name": "stree",
+        "yearReleased": "2019",
+        "language": "Hindi",
+        "director": "Amar Kaushik"
+    },
+    {
+        "id": 27,
+        "name": "sinister",
+        "yearReleased": "2012",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 27,
+        "name": "1920",
+        "yearReleased": "2008",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 28,
+        "name": "Train to Busan",
+        "yearReleased": " 2016",
+        "language": "korean",
+        "director": "Yeon Sang-ho"
+    },
+    {
+        "id": 27,
+        "name": "sinister2",
+        "yearReleased": "2015",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 33,
+        "name": "Tumbad",
+        "yearReleased": "2018",
+        "language": "Hindi",
+        "director": "Rahi Barve"
+    },
+    {
+        "id": 99,
+        "name": "kalo",
+        "yearReleased": "1960",
+        "language": "hindi",
+        "director": "pata nahi"
+    },
+    {
+        "id": 27,
+        "name": "Bhootkaal",
+        "yearReleased": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 27,
+        "name": "sinister",
+        "yearReleased": "2012",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 27,
+        "name": "1920",
+        "yearReleased": "2008",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 28,
+        "name": "Train to Busan",
+        "yearReleased": " 2016",
+        "language": "korean",
+        "director": "Yeon Sang-ho"
+    },
+    {
+        "id": 27,
+        "name": "sinister2",
+        "yearReleased": "2015",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 21,
+        "name": "The Nun",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Corin Hardy"
+    },
+    {
+        "id": 33,
+        "name": "Tumbad",
+        "yearReleased": "2018",
+        "language": "Hindi",
+        "director": "Rahi Barve"
+    },
+    {
+        "id": 99,
+        "name": "kalo",
+        "yearReleased": "1960",
+        "language": "hindi",
+        "director": "pata nahi"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "shaapit",
+        "yearReleased": "2010",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 27,
+        "name": "Bhootkaal",
+        "yearReleased": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 21,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "TZach Cregger"
+    },
+    {
+        "id": 20,
+        "name": "Wrong Turn",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 55,
+        "name": "Malignant",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 24,
+        "name": "IT",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Andrés Muschietti"
+    },
+    {
+        "id": 26,
+        "name": "Host",
+        "yearReleased": "2020",
+        "language": "English",
+        "director": "Andy dataser"
+    },
+    {
+        "id": 25,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 21,
+        "name": "Anabella",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "John R. Leonetti"
+    },
+    {
+        "id": 27,
+        "name": "sinister2",
+        "yearReleased": "2015",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 33,
+        "name": "Tumbad",
+        "yearReleased": "2018",
+        "language": "Hindi",
+        "director": "Rahi Barve"
+    },
+    {
+        "id": 99,
+        "name": "kalo",
+        "yearReleased": "1960",
+        "language": "hindi",
+        "director": "pata nahi"
+    },
+    {
+        "id": 27,
+        "name": "Bhootkaal",
+        "yearReleased": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 56,
+        "name": "Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 29,
+        "name": "Hereditary",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Ari Aster"
+    },
+    {
+        "id": 22,
+        "name": "Roohi",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Hardik Mehta"
+    },
+    {
+        "id": 23,
+        "name": "Stree",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Amar Kaushik"
+    },
+    {
+        "id": 26,
+        "name": "Host",
+        "yearReleased": "2020",
+        "language": "English",
+        "director": "Andy dataser"
+    },
+    {
+        "id": 7008,
+        "name": "Handjob Cabin",
+        "yearReleased": "2015",
+        "language": "English",
+        "director": "Bennet Silverman"
+    },
+    {
+        "id": 21,
+        "name": " Chhorii",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Vishal Furia"
+    },
+    {
+        "id": 27,
+        "name": "kanchan",
+        "yearReleased": "2013",
+        "language": "Hindi",
+        "director": "ssr"
+    },
+    {
+        "id": 21,
+        "name": "Host",
+        "yearRealeased": "2020",
+        "language": "English",
+        "director": "Rob Savage"
+    },
+    {
+        "id": 22,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "William Friedkin"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "Corin Hardy"
+    },
+    {
+        "id": 21,
+        "name": "stree",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "BANSALI"
+    },
+    {
+        "id": 21,
+        "name": "The Shining",
+        "yearReleased": "1980",
+        "language": "English",
+        "director": "Stanley Kubrick"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 56,
+        "name": "Lights Out ",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "David F. Sandberg"
+    },
+    {
+        "id": 57,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "English",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 56,
+        "name": "Old",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "M. Night Shyamalan"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 56,
+        "name": "Lights Out ",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "David F. Sandberg"
+    },
+    {
+        "id": 20,
+        "name": "Chhorii",
+        "yearReleased": "2021",
+        "language": "hindi",
+        "director": "Vishal Furia"
+    },
+    {
+        "id": 21,
+        "name": "Veronica",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Paco Plaza"
+    },
+    {
+        "id": 21,
+        "name": "6-5=2",
+        "yearReleased": "2014",
+        "language": "HINDI",
+        "director": "Bharat Jain"
+    },
+    {
+        "id": 22,
+        "name": "brahmastra",
+        "yearReleased": "2022",
+        "language": "HINDI",
+        "director": "Ayan Mukerji"
+    },
+    {
+        "id": 21,
+        "name": "IT'S ALIVE! ",
+        "yearReleased": "1974",
+        "language": "English",
+        "director": "Larry Cohen"
+    },
+    {
+        "id": 28,
+        "name": "The Grudge",
+        "yearReleased": "2004",
+        "language": "Japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 21,
+        "name": "Haunted – 3D",
+        "yearReleased": "2011",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 79,
+        "name": "The Ring",
+        "yearReleased": "2003",
+        "language": "English",
+        "director": "Gore Verbinski"
+    },
+    {
+        "id": 22,
+        "name": "The Conjuring 2",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 23,
+        "name": "Resident Evil",
+        "yearReleased": "2002",
+        "language": "English",
+        "director": "Paul W.S. Anderson"
+    },
+    {
+        "id": 21,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "John boorman"
+    },
+    {
+        "id": 29,
+        "name": "The Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 23,
+        "name": "IT",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Andy Muschietti"
+    },
+    {
+        "id": 24,
+        "name": "Get Out",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Jordan Peele"
+    },
+    {
+        "id": 231,
+        "name": "Halloween Kills",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "David Gordon Green"
+    },
     {
         "id": 1,
         "name": "Host",
@@ -2259,2413 +2257,2409 @@
         "language": "English",
         "director": "Gary Dauberman"
     },
-  {
-      "id": 1,
-      "name": "Host",
-      "yearReleased": "2020",
-      "language": "English",
-      "director": "Andy dataser"
-  },
-  {
-      "id": 2,
-      "name": "Host",
-      "yearReleased": "2018",
-      "language": "English",
-      "director": "Andy Newber"
-  },
-  {
-      "id": 3,
-      "name": "The Ring",
-      "yearReleased": "2004",
-      "language": "English",
-      "director": "Andy Newsir"
-  },
-  {
-      "id": 4,
-      "name": "Dahmer",
-      "yearReleased": "2002",
-      "language": "English",
-      "director": "David Jacobson"
-  },
-  {
-      "id": 5,
-      "name": "The Conjuring",
-      "yearReleased": "2013",
-      "language": "English",
-      "director": "James Wan"
-  },
-  {
-      "id": 6,
-      "name": "one missed call",
-      "yearReleased": "2008",
-      "language": "English",
-      "director": "Eric Vallete"
-  },
-  {
-      "id": 7,
-      "name": "The Midnigth club",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "Mike Flannagan"
-  },
-  {
-      "id": 8,
-      "name": "Insidious",
-      "yearReleased": "2010",
-      "language": "English",
-      "director": "James Wan"
-  },
-  {
-      "id": 9,
-      "name": "Veronica",
-      "yearReleased": "2017",
-      "language": "English",
-      "director": "plazo"
-  },
-  {
-      "id": 10,
-      "name": "Lights Out ",
-      "yearReleased": "2016",
-      "language": "English",
-      "director": "David F. Sandberg"
-  },
-  {
-      "id": 11,
-      "name": "Veronica",
-      "yearReleased": "2017",
-      "language": "English",
-      "director": "paco plazo"
-  },
-  {
-      "id": 12,
-      "name": " The Omen in Devil Town ",
-      "yearReleased": "1993",
-      "language": "English",
-      "director": "Qumin Lee"
-  },
-  {
-      "id": 13,
-      "name": "Bhootkaal",
-      "yearReleased": "2003",
-      "language": "Hindi",
-      "director": "Ram Gopal Varma"
-  },
-  {
-      "id": 14,
-      "name": " 6 and 1 (In the Mind)",
-      "yearReleased": "2019",
-      "language": "English",
-      "director": "Sudhanshu Saria"
-  },
-  {
-      "id": 15,
-      "name": "Faz-me Companhia",
-      "yearReleased": "2019",
-      "language": "English",
-      "director": "João Pedro Rodrigues"
-  },
-  {
-      "id": 16,
-      "name": "The Conjuring",
-      "yearReleased": "2013",
-      "language": "English",
-      "director": "James Wan"
-  },
-  {
-      "id": 17,
-      "name": "Paranormal Activity",
-      "yearReleased": "2007",
-      "language": "English",
-      "director": "Oren Peli"
-  },
-  {
-      "id": 18,
-      "name": "Paranormal Activity 2",
-      "yearReleased": "2010",
-      "language": "English",
-      "director": "Tod Williams"
-  },
-  {
-      "id": 19,
-      "name": "Paranormal Activity 3",
-      "yearReleased": "2011",
-      "language": "English",
-      "director": "Henry joost,Ariel Schulman"
-  },
-  {
-      "id": 20,
-      "name": "Paranormal Activity 4",
-      "yearReleased": "2012",
-      "language": "English",
-      "director": "Henry joost,Ariel Schulman"
-  },
-  {
-      "id": 20,
-      "name": "Kanchana",
-      "yearReleased": "2016",
-      "language": "Tamil",
-      "director": "Indian Insan"
-  },
-  {
-      "id": 22,
-      "name": "X",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "Ti West"
-  },
-  {
-      "id": 23,
-      "name": " Barbarian",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "TZach Cregger"
-  },
-  {
-      "id": 21,
-      "name": "The Exorcist",
-      "yearReleased": "1973",
-      "language": "English",
-      "director": "William Friedkin"
-  },
-  {
-      "id": 20,
-      "name": "Wrong Turn",
-      "yearReleased": "2021",
-      "language": "English",
-      "director": "Mike P. Nelson"
-  },
-  {
-      "id": 25,
-      "name": "Wrong Turn",
-      "yearReleased": "2021",
-      "language": "English",
-      "director": "Mike P. Nelson"
-  },
-  {
-      "id": 26,
-      "name": "Videodrome",
-      "yearReleased": "1983",
-      "language": "English",
-      "director": " David Cronenberg"
-  },
-  {
-      "id": 27,
-      "name": " Horror Story",
-      "yearReleased": "2013",
-      "language": "Hindi",
-      "director": "Ayush Raina"
-  },
-  {
-      "id": 28,
-      "name": "The Exorcist",
-      "yearReleased": "2018",
-      "language": "English",
-      "director": "Andy Newber"
-  },
-  {
-      "id": 29,
-      "name": "The Weird Man",
-      "yearReleased": "2021",
-      "language": "English",
-      "director": "Mike P. Nelson"
-  },
-  {
-      "id": 30,
-      "name": "Psycho",
-      "yearReleased": "1960",
-      "language": "English",
-      "director": " Alfred Hitchcock"
-  },
-  {
-      "id": 31,
-      "name": "Psycho",
-      "yearReleased": "1960",
-      "language": "English",
-      "director": " Alfred Hitchcock"
-  },
-  {
-      "id": 21,
-      "name": "Psycho",
-      "yearReleased": "1960",
-      "language": "English",
-      "director": " Alfred Hitchcock"
-  },
-  {
-      "id": 32,
-      "name": "X",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "Ti West"
-  },
-  {
-      "id": 33,
-      "name": "Annabelle",
-      "yearReleased": "2014",
-      "language": "English",
-      "director": " John R. Leonetti"
-  },
-  {
-      "id": 34,
-      "name": "nightmare of the elm street",
-      "yearReleased": "1984",
-      "language": "English",
-      "director": "Wes Craven"
-  },
-  {
-      "id": 35,
-      "name": "Bhool Bhulaiyaa 2",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "Anees Bazmee"
-  },
-  {
-      "id": 36,
-      "name": "Bhoot",
-      "yearReleased": "2022",
-      "language": "Hindi",
-      "director": "Bhanu Pratap Singh"
-  },
-  {
-      "id": 37,
-      "name": "Alien: Covenant",
-      "yearReleased": " 2017",
-      "language": "English",
-      "director": "Ridley Scott"
-  },
-  {
-      "id": 27,
-      "name": "6-5=2",
-      "yearReleased": "2013",
-      "language": "Kannada",
-      "director": "K S Ashoka"
-  },
-  {
-      "id": 21,
-      "name": "Dybbuk",
-      "yearReleased": "2021",
-      "language": "Hindi",
-      "director": "Jay Krishnan"
-  },
-  {
-      "id": 28,
-      "name": "House Of Usher",
-      "yearReleased": "1960",
-      "language": "English",
-      "director": "Roger Corman"
-  },
-  {
-      "id": 21,
-      "name": "The Unholy",
-      "yearReleased": "2021",
-      "language": "English",
-      "director": "Evan Spiliotopoulos"
-  },
-  {
-      "id": 23,
-      "name": "The Midnigth club",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "Mike Flannagan"
-  },
-  {
-      "id": 21,
-      "name": "Psycho",
-      "yearReleased": "1960",
-      "language": "English",
-      "director": " Alfred Hitchcock"
-  },
-  {
-      "id": 21,
-      "name": "X",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "Ti West"
-  },
-  {
-      "id": 22,
-      "name": "Annabelle",
-      "yearReleased": "2014",
-      "language": "English",
-      "director": " John R. Leonetti"
-  },
-  {
-      "id": 23,
-      "name": "nightmare of the elm street",
-      "yearReleased": "1984",
-      "language": "English",
-      "director": "Wes Craven"
-  },
-  {
-      "id": 24,
-      "name": "Bhool Bhulaiyaa 2",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "Anees Bazmee"
-  },
-  {
-      "id": 25,
-      "name": "Bhoot",
-      "yearReleased": "2022",
-      "language": "Hindi",
-      "director": "Bhanu Pratap Singh"
-  },
-  {
-      "id": 26,
-      "name": "Alien: Covenant",
-      "yearReleased": " 2017",
-      "language": "English",
-      "director": "Ridley Scott"
-  },
-  {
-      "id": 27,
-      "name": "6-5=2",
-      "yearReleased": "2013",
-      "language": "Kannada",
-      "director": "K S Ashoka"
-  },
-  {
-      "id": 21,
-      "name": "Dybbuk",
-      "yearReleased": "2021",
-      "language": "Hindi",
-      "director": "Jay Krishnan"
-  },
-  {
-      "id": 28,
-      "name": "House Of Usher",
-      "yearReleased": "1960",
-      "language": "English",
-      "director": "Roger Corman"
-  },
-  {
-      "id": 21,
-      "name": "The Unholy",
-      "yearReleased": "2021",
-      "language": "English",
-      "director": "Evan Spiliotopoulos"
-  },
-  {
-      "id": 23,
-      "name": "The Midnigth club",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "Mike Flannagan"
-  },
-  {
-      "id": 25,
-      "name": "Bhoot",
-      "yearReleased": "2022",
-      "language": "Hindi",
-      "director": "Bhanu Pratap Singh"
-  },
-  {
-      "id": 26,
-      "name": "Alien: Covenant",
-      "yearReleased": " 2017",
-      "language": "English",
-      "director": "Ridley Scott"
-  },
-  {
-      "id": 27,
-      "name": "6-5=2",
-      "yearReleased": "2013",
-      "language": "Kannada",
-      "director": "K S Ashoka"
-  },
-  {
-      "id": 21,
-      "name": "Dybbuk",
-      "yearReleased": "2021",
-      "language": "Hindi",
-      "director": "Jay Krishnan"
-  },
-  {
-      "id": 28,
-      "name": "House Of Usher",
-      "yearReleased": "1960",
-      "language": "English",
-      "director": "Roger Corman"
-  },
-  {
-      "id": 21,
-      "name": "stree",
-      "yearReleased": "2020",
-      "language": "Hindi",
-      "director": "dev deol"
-  },
-  {
-      "id": 21,
-      "name": "Psycho",
-      "yearReleased": "1960",
-      "language": "English",
-      "director": " Alfred Hitchcock"
-  },
-  {
-      "id": 24,
-      "name": "Dead Silence",
-      "yearReleased": "2007",
-      "language": "English",
-      "director": "James Wan"
-  },
-  {
-      "id": 21,
-      "name": "Mahal",
-      "yearReleased": "1949",
-      "language": "Hindi",
-      "director": "Kamal Amrohi"
-  },
-  {
-      "id": 30,
-      "name": "US",
-      "yearReleased": "2019",
-      "language": "English",
-      "director": "Jordan Peele"
-  },
-  {
-      "id": 50,
-      "name": "1920",
-      "yearReleased": "2008",
-      "language": "Hindi",
-      "director": "Vikram Bhatt"
-  },
-  {
-      "id": 21,
-      "name": "Annabelle",
-      "yearReleased": "2014",
-      "language": "English",
-      "director": " John R. Leonetti"
-  },
-  {
-      "id": 28,
-      "name": "Midsommar",
-      "yearReleased": "2019",
-      "language": "English",
-      "director": " Ari Aster"
-  },
-  {},
-  {
-      "id": 23,
-      "name": "The Midnigth club",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "Mike Flannagan"
-  },
-  {
-      "id": 29,
-      "name": "Orphan",
-      "yearReleased": "2009",
-      "language": "English",
-      "director": "Jaume Collet-Serra"
-  },
-  {
-      "id": 21,
-      "name": "The Exorcist",
-      "yearReleased": "1973",
-      "language": "English",
-      "director": "William Friedkin"
-  },
-  {
-      "id": 22,
-      "name": "Bhool Bhulaiyaa 2",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "Anees Bazmee"
-  },
-  {},
-  {
-      "id": 24,
-      "name": "6-5=2",
-      "yearReleased": "2013",
-      "language": "Kannada",
-      "director": "K S Ashoka"
-  },
-  {
-      "id": 22,
-      "name": "Arundhati",
-      "yearReleased": "2009",
-      "language": "Telugu",
-      "director": "Kodi Ramakrishna"
-  },
-  {
-      "id": 25,
-      "name": "Nope",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "Jordan Peele"
-  },
-  {
-      "id": 32,
-      "name": "Bhool Bhulaiyaa  ",
-      "yearReleased": "2007",
-      "language": "Hindi",
-      "director": "Priyadarshan"
-  },
-  {
-      "id": 32,
-      "name": "stree",
-      "yearReleased": "2019",
-      "language": "Hindi",
-      "director": "Amar Kaushik"
-  },
-  {
-      "id": 27,
-      "name": "sinister",
-      "yearReleased": "2012",
-      "language": "english",
-      "director": "scott derrickson"
-  },
-  {
-      "id": 27,
-      "name": "1920",
-      "yearReleased": "2008",
-      "language": "Hindi",
-      "director": "Vikram Bhatt"
-  },
-  {
-      "id": 28,
-      "name": "Train to Busan",
-      "yearReleased": " 2016",
-      "language": "korean",
-      "director": "Yeon Sang-ho"
-  },
-  {
-      "id": 27,
-      "name": "sinister2",
-      "yearReleased": "2015",
-      "language": "english",
-      "director": "scott derrickson"
-  },
-  {
-      "id": 33,
-      "name": "Tumbad",
-      "yearReleased": "2018",
-      "language": "Hindi",
-      "director": "Rahi Barve"
-  },
-  {
-      "id": 99,
-      "name": "kalo",
-      "yearReleased": "1960",
-      "language": "hindi",
-      "director": "pata nahi"
-  },
-  {
-      "id": 27,
-      "name": "Bhootkaal",
-      "yearReleased": "2003",
-      "language": "Hindi",
-      "director": "Ram Gopal Varma"
-  },
-  {
-      "id": 52,
-      "name": "Alone",
-      "yearReleased": "2015",
-      "language": "Hindi",
-      "director": "Bhushan Patel"
-  },
-  {
-      "id": 53,
-      "name": "vyanki the Dian",
-      "yearReleased": "2022",
-      "language": "Russian",
-      "director": "Vishal chauhan"
-  },
-  {
-      "id": 27,
-      "name": "sinister",
-      "yearReleased": "2012",
-      "language": "english",
-      "director": "scott derrickson"
-  },
-  {
-      "id": 27,
-      "name": "1920",
-      "yearReleased": "2008",
-      "language": "Hindi",
-      "director": "Vikram Bhatt"
-  },
-  {
-      "id": 28,
-      "name": "Train to Busan",
-      "yearReleased": " 2016",
-      "language": "korean",
-      "director": "Yeon Sang-ho"
-  },
-  {
-      "id": 27,
-      "name": "sinister2",
-      "yearReleased": "2015",
-      "language": "english",
-      "director": "scott derrickson"
-  },
-  {
-      "id": 21,
-      "name": "The Nun",
-      "yearReleased": "2018",
-      "language": "English",
-      "director": "Corin Hardy"
-  },
-  {
-      "id": 33,
-      "name": "Tumbad",
-      "yearReleased": "2018",
-      "language": "Hindi",
-      "director": "Rahi Barve"
-  },
-  {
-      "id": 99,
-      "name": "kalo",
-      "yearReleased": "1960",
-      "language": "hindi",
-      "director": "pata nahi"
-  },
-  {
-      "id": 52,
-      "name": "Alone",
-      "yearReleased": "2015",
-      "language": "Hindi",
-      "director": "Bhushan Patel"
-  },
-  {
-      "id": 53,
-      "name": "vyanki the Dian",
-      "yearReleased": "2022",
-      "language": "Russian",
-      "director": "Vishal chauhan"
-  },
-  {
-      "id": 54,
-      "name": "shaapit",
-      "yearReleased": "2010",
-      "language": "Hindi",
-      "director": "Vikram Bhatt"
-  },
-  {
-      "id": 27,
-      "name": "Bhootkaal",
-      "yearReleased": "2003",
-      "language": "Hindi",
-      "director": "Ram Gopal Varma"
-  },
-  {
-      "id": 21,
-      "name": "Bhool Bhulaiyaa 2",
-      "yearReleased": "2022",
-      "language": "English",
-      "director": "TZach Cregger"
-  },
-  {
-      "id": 20,
-      "name": "Wrong Turn",
-      "yearReleased": "2021",
-      "language": "English",
-      "director": "Mike P. Nelson"
-  },
-  {
-      "id": 55,
-      "name": "Malignant",
-      "yearReleased": "2021",
-      "language": "English",
-      "director": "James Wan"
-  },
-  {
-      "id": 24,
-      "name": "IT",
-      "yearReleased": "2017",
-      "language": "English",
-      "director": "Andrés Muschietti"
-  },
-  {
-      "id": 26,
-      "name": "Host",
-      "yearReleased": "2020",
-      "language": "English",
-      "director": "Andy dataser"
-  },
-  {
-      "id": 25,
-      "name": "Bhoot",
-      "yearReleased": "2022",
-      "language": "Hindi",
-      "director": "Bhanu Pratap Singh"
-  },
-  {
-      "id": 21,
-      "name": "Anabella",
-      "yearReleased": "2017",
-      "language": "English",
-      "director": "John R. Leonetti"
-  },
-  {
-      "id": 27,
-      "name": "sinister2",
-      "yearReleased": "2015",
-      "language": "english",
-      "director": "scott derrickson"
-  },
-  {
-      "id": 33,
-      "name": "Tumbad",
-      "yearReleased": "2018",
-      "language": "Hindi",
-      "director": "Rahi Barve"
-  },
-  {
-      "id": 99,
-      "name": "kalo",
-      "yearReleased": "1960",
-      "language": "hindi",
-      "director": "pata nahi"
-  },
-  {
-      "id": 27,
-      "name": "Bhootkaal",
-      "yearReleased": "2003",
-      "language": "Hindi",
-      "director": "Ram Gopal Varma"
-  },
-  {
-      "id": 52,
-      "name": "Alone",
-      "yearReleased": "2015",
-      "language": "Hindi",
-      "director": "Bhushan Patel"
-  },
-  {
-      "id": 53,
-      "name": "vyanki the Dian",
-      "yearReleased": "2022",
-      "language": "Russian",
-      "director": "Vishal chauhan"
-  },
-  {
-      "id": 56,
-      "name": "Conjuring",
-      "yearReleased": "2013",
-      "language": "English",
-      "director": "James Wan"
-  },
-  {
-      "id": 29,
-      "name": "Hereditary",
-      "yearReleased": "2018",
-      "language": "English",
-      "director": "Ari Aster"
-  },
-  {
-      "id": 22,
-      "name": "Roohi",
-      "yearReleased": "2021",
-      "language": "English",
-      "director": "Hardik Mehta"
-  },
-  {
-      "id": 23,
-      "name": "Stree",
-      "yearReleased": "2018",
-      "language": "English",
-      "director": "Amar Kaushik"
-  },
-  {
-      "id": 26,
-      "name": "Host",
-      "yearReleased": "2020",
-      "language": "English",
-      "director": "Andy dataser"
-  },
-  {
-      "id": 7008,
-      "name": "Handjob Cabin",
-      "yearReleased": "2015",
-      "language": "English",
-      "director": "Bennet Silverman"
-  },
-  {
-      "id": 21,
-      "name": " Chhorii",
-      "yearReleased": "2017",
-      "language": "English",
-      "director": "Vishal Furia"
-  },
-  {
-      "id": 27,
-      "name": "kanchan",
-      "yearReleased": "2013",
-      "language": "Hindi",
-      "director": "ssr"
-  },
-  {
-      "id": 21,
-      "name": "Host",
-      "yearRealeased": "2020",
-      "language": "English",
-      "director": "Rob Savage"
-  },
-  {
-      "id": 22,
-      "name": "The Exorcist",
-      "yearReleased": "1973",
-      "language": "English",
-      "director": "William Friedkin"
-  },
-  {
-      "id": 52,
-      "name": "Alone",
-      "yearReleased": "2015",
-      "language": "Hindi",
-      "director": "Bhushan Patel"
-  },
-  {
-      "id": 53,
-      "name": "vyanki the Dian",
-      "yearReleased": "2022",
-      "language": "Russian",
-      "director": "Vishal chauhan"
-  },
-  {
-      "id": 54,
-      "name": "The Woman in Black",
-      "yearReleased": "2012",
-      "language": "English",
-      "director": "James Watkins"
-  },
-  {
-      "id": 55,
-      "name": "Innocent Curse",
-      "yearReleased": "2017",
-      "language": "japanese",
-      "director": "Takashi Shimizu"
-  },{
-    "id": 56,
-    "name": "Lights Out ",
-    "yearReleased": "2016",
-    "language": "English",
-    "director": "David F. Sandberg"
-  },
-  
-  {
-    "id": 57,
-    "name": "Aftermath",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": " Peter Winther"
-  },
-  {
-      "id": 52,
-      "name": "Alone",
-      "yearReleased": "2015",
-      "language": "Hindi",
-      "director": "Bhushan Patel"
-  },
-  {
-      "id": 53,
-      "name": "vyanki the Dian",
-      "yearReleased": "2022",
-      "language": "Russian",
-      "director": "Vishal chauhan"
-  },
-  {
-      "id": 54,
-      "name": "The Woman in Black",
-      "yearReleased": "2012",
-      "language": "English",
-      "director": "Corin Hardy"
-  },
-  {
-      "id": 21,
-      "name": "stree",
-      "yearReleased": "2021",
-      "language": "Hindi",
-      "director": "BANSALI"
-  },
-  {
-      "id": 21,
-      "name": "The Shining",
-      "yearReleased": "1980",
-      "language": "English",
-      "director": "Stanley Kubrick"
-  },
-  {
-      "id": 52,
-      "name": "Alone",
-      "yearReleased": "2015",
-      "language": "Hindi",
-      "director": "Bhushan Patel"
-  },
-  {
-      "id": 53,
-      "name": "vyanki the Dian",
-      "yearReleased": "2022",
-      "language": "Russian",
-      "director": "Vishal chauhan"
-  },
-  {
-      "id": 54,
-      "name": "The Woman in Black",
-      "yearReleased": "2012",
-      "language": "English",
-      "director": "James Watkins"
-  },
-  {
-      "id": 52,
-      "name": "Alone",
-      "yearReleased": "2015",
-      "language": "Hindi",
-      "director": "Bhushan Patel"
-  },
-  {
-      "id": 53,
-      "name": "vyanki the Dian",
-      "yearReleased": "2022",
-      "language": "Russian",
-      "director": "Vishal chauhan"
-  },
-  {
-      "id": 54,
-      "name": "The Woman in Black",
-      "yearReleased": "2012",
-      "language": "English",
-      "director": "James Watkins"
-  },
-  {
-      "id": 55,
-      "name": "Innocent Curse",
-      "yearReleased": "2017",
-      "language": "japanese",
-      "director": "Takashi Shimizu"
-  },
-  {
-      "id": 56,
-      "name": "Lights Out ",
-      "yearReleased": "2016",
-      "language": "English",
-      "director": "David F. Sandberg"
-  },
-  {
-      "id": 57,
-      "name": "Alone",
-      "yearReleased": "2015",
-      "language": "English",
-      "director": "Bhushan Patel"
-  },
-  {
-      "id": 55,
-      "name": "Innocent Curse",
-      "yearReleased": "2017",
-      "language": "japanese",
-      "director": "Takashi Shimizu"
-  },
-  {
-      "id": 56,
-      "name": "Old",
-      "yearReleased": "2021",
-      "language": "English",
-      "director": "M. Night Shyamalan"
-  },
-  {
-      "id": 55,
-      "name": "Innocent Curse",
-      "yearReleased": "2017",
-      "language": "japanese",
-      "director": "Takashi Shimizu"
-  },
-  {
-      "id": 56,
-      "name": "Lights Out ",
-      "yearReleased": "2016",
-      "language": "English",
-      "director": "David F. Sandberg"
-  },
-  {
-      "id": 20,
-      "name": "Chhorii",
-      "yearReleased": "2021",
-      "language": "hindi",
-      "director": "Vishal Furia"
-  },
-  {
-      "id": 21,
-      "name": "Veronica",
-      "yearReleased": "2017",
-      "language": "English",
-      "director": "Paco Plaza"
-  },
-  {
-      "id": 21,
-      "name": "6-5=2",
-      "yearReleased": "2014",
-      "language": "HINDI",
-      "director": "Bharat Jain"
-  },
-  {
-      "id": 22,
-      "name": "brahmastra",
-      "yearReleased": "2022",
-      "language": "HINDI",
-      "director": "Ayan Mukerji"
-  },
-  {
-      "id": 21,
-      "name": "IT'S ALIVE! ",
-      "yearReleased": "1974",
-      "language": "English",
-      "director": "Larry Cohen"
-  },
-  {
-      "id": 28,
-      "name": "The Grudge",
-      "yearReleased": "2004",
-      "language": "Japanese",
-      "director": "Takashi Shimizu"
-  },
-  {
-      "id": 21,
-      "name": "Haunted – 3D",
-      "yearReleased": "2011",
-      "language": "Hindi",
-      "director": "Vikram Bhatt"
-  },
-  {
-      "id": 52,
-      "name": "Alone",
-      "yearReleased": "2015",
-      "language": "Hindi",
-      "director": "Bhushan Patel"
-  },
-  {
-      "id": 53,
-      "name": "vyanki the Dian",
-      "yearReleased": "2022",
-      "language": "Russian",
-      "director": "Vishal chauhan"
-  },
-  {
-      "id": 54,
-      "name": "The Woman in Black",
-      "yearReleased": "2012",
-      "language": "English",
-      "director": "James Watkins"
-  },
-  {
-      "id": 55,
-      "name": "Innocent Curse",
-      "yearReleased": "2017",
-      "language": "japanese",
-      "director": "Takashi Shimizu"
-  },
-  {
-      "id": 79,
-      "name": "The Ring",
-      "yearReleased": "2003",
-      "language": "English",
-      "director": "Gore Verbinski"
-  },
-  {
-      "id": 22,
-      "name": "The Conjuring 2",
-      "yearReleased": "2016",
-      "language": "English",
-      "director": "James Wan"
-  },
-  {
-      "id": 23,
-      "name": "Resident Evil",
-      "yearReleased": "2002",
-      "language": "English",
-      "director": "Paul W.S. Anderson"
-  },
-  {
-      "id": 21,
-      "name": "The Exorcist",
-      "yearReleased": "1973",
-      "language": "English",
-      "director": "John boorman"
-  },
-  {
-      "id": 29,
-      "name": "The Conjuring",
-      "yearReleased": "2013",
-      "language": "English",
-      "director": "James Wan"
-  },
-  {
-      "id": 23,
-      "name": "IT",
-      "yearReleased": "2017",
-      "language": "English",
-      "director": "Andy Muschietti"
-  },
-  {
-      "id": 24,
-      "name": "Get Out",
-      "yearReleased": "2017",
-      "language": "English",
-      "director": "Jordan Peele"
-  },
-{
-    "id": 1,
-    "name": "Host",
-    "yearReleased": "2020",
-    "language": "English",
-    "director": "Andy dataser"
-},
-{
-    "id": 2,
-    "name": "Host",
-    "yearReleased": "2018",
-    "language": "English",
-    "director": "Andy Newber"
-},
-{
-    "id": 3,
-    "name": "The Ring",
-    "yearReleased": "2004",
-    "language": "English",
-    "director": "Andy Newsir"
-},
-{
-    "id": 4,
-    "name": "Dahmer",
-    "yearReleased": "2002",
-    "language": "English",
-    "director": "David Jacobson"
-},
-{
-    "id": 5,
-    "name": "The Conjuring",
-    "yearReleased": "2013",
-    "language": "English",
-    "director": "James Wan"
-},
-{
-    "id": 6,
-    "name": "one missed call",
-    "yearReleased": "2008",
-    "language": "English",
-    "director": "Eric Vallete"
-},
-{
-    "id": 7,
-    "name": "The Midnigth club",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "Mike Flannagan"
-},
-{
-    "id": 8,
-    "name": "Insidious",
-    "yearReleased": "2010",
-    "language": "English",
-    "director": "James Wan"
-},
-{
-    "id": 9,
-    "name": "Veronica",
-    "yearReleased": "2017",
-    "language": "English",
-    "director": "plazo"
-},
-{
-    "id": 10,
-    "name": "Lights Out ",
-    "yearReleased": "2016",
-    "language": "English",
-    "director": "David F. Sandberg"
-},
-{
-    "id": 11,
-    "name": "Veronica",
-    "yearReleased": "2017",
-    "language": "English",
-    "director": "paco plazo"
-},
-{
-    "id": 12,
-    "name": " The Omen in Devil Town ",
-    "yearReleased": "1993",
-    "language": "English",
-    "director": "Qumin Lee"
-},
-{
-    "id": 13,
-    "name": "Bhootkaal",
-    "yearReleased": "2003",
-    "language": "Hindi",
-    "director": "Ram Gopal Varma"
-},
-{
-    "id": 14,
-    "name": " 6 and 1 (In the Mind)",
-    "yearReleased": "2019",
-    "language": "English",
-    "director": "Sudhanshu Saria"
-},
-{
-    "id": 15,
-    "name": "Faz-me Companhia",
-    "yearReleased": "2019",
-    "language": "English",
-    "director": "João Pedro Rodrigues"
-},
-{
-    "id": 16,
-    "name": "The Conjuring",
-    "yearReleased": "2013",
-    "language": "English",
-    "director": "James Wan"
-},
-{
-    "id": 17,
-    "name": "Paranormal Activity",
-    "yearReleased": "2007",
-    "language": "English",
-    "director": "Oren Peli"
-},
-{
-    "id": 18,
-    "name": "Paranormal Activity 2",
-    "yearReleased": "2010",
-    "language": "English",
-    "director": "Tod Williams"
-},
-{
-    "id": 19,
-    "name": "Paranormal Activity 3",
-    "yearReleased": "2011",
-    "language": "English",
-    "director": "Henry joost,Ariel Schulman"
-},
-{
-    "id": 20,
-    "name": "Paranormal Activity 4",
-    "yearReleased": "2012",
-    "language": "English",
-    "director": "Henry joost,Ariel Schulman"
-},
-{
-    "id": 20,
-    "name": "Kanchana",
-    "yearReleased": "2016",
-    "language": "Tamil",
-    "director": "Indian Insan"
-},
-{
-    "id": 22,
-    "name": "X",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "Ti West"
-},
-{
-    "id": 23,
-    "name": " Barbarian",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "TZach Cregger"
-},
-{
-    "id": 21,
-    "name": "The Exorcist",
-    "yearReleased": "1973",
-    "language": "English",
-    "director": "William Friedkin"
-},
-{
-    "id": 20,
-    "name": "Wrong Turn",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": "Mike P. Nelson"
-},
-{
-    "id": 25,
-    "name": "Wrong Turn",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": "Mike P. Nelson"
-},
-{
-    "id": 26,
-    "name": "Videodrome",
-    "yearReleased": "1983",
-    "language": "English",
-    "director": " David Cronenberg"
-},
-{
-    "id": 27,
-    "name": " Horror Story",
-    "yearReleased": "2013",
-    "language": "Hindi",
-    "director": "Ayush Raina"
-},
-{
-    "id": 28,
-    "name": "The Exorcist",
-    "yearReleased": "2018",
-    "language": "English",
-    "director": "Andy Newber"
-},
-{
-    "id": 29,
-    "name": "The Weird Man",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": "Mike P. Nelson"
-},
-{
-    "id": 30,
-    "name": "Psycho",
-    "yearReleased": "1960",
-    "language": "English",
-    "director": " Alfred Hitchcock"
-},
-{
-    "id": 31,
-    "name": "Psycho",
-    "yearReleased": "1960",
-    "language": "English",
-    "director": " Alfred Hitchcock"
-},
-{
-    "id": 21,
-    "name": "Psycho",
-    "yearReleased": "1960",
-    "language": "English",
-    "director": " Alfred Hitchcock"
-},
-{
-    "id": 32,
-    "name": "X",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "Ti West"
-},
-{
-    "id": 33,
-    "name": "Annabelle",
-    "yearReleased": "2014",
-    "language": "English",
-    "director": " John R. Leonetti"
-},
-{
-    "id": 34,
-    "name": "nightmare of the elm street",
-    "yearReleased": "1984",
-    "language": "English",
-    "director": "Wes Craven"
-},
-{
-    "id": 35,
-    "name": "Bhool Bhulaiyaa 2",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "Anees Bazmee"
-},
-{
-    "id": 36,
-    "name": "Bhoot",
-    "yearReleased": "2022",
-    "language": "Hindi",
-    "director": "Bhanu Pratap Singh"
-},
-{
-    "id": 37,
-    "name": "Alien: Covenant",
-    "yearReleased": " 2017",
-    "language": "English",
-    "director": "Ridley Scott"
-},
-{
-    "id": 27,
-    "name": "6-5=2",
-    "yearReleased": "2013",
-    "language": "Kannada",
-    "director": "K S Ashoka"
-},
-{
-    "id": 21,
-    "name": "Dybbuk",
-    "yearReleased": "2021",
-    "language": "Hindi",
-    "director": "Jay Krishnan"
-},
-{
-    "id": 28,
-    "name": "House Of Usher",
-    "yearReleased": "1960",
-    "language": "English",
-    "director": "Roger Corman"
-},
-{
-    "id": 21,
-    "name": "The Unholy",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": "Evan Spiliotopoulos"
-},
-{
-    "id": 23,
-    "name": "The Midnigth club",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "Mike Flannagan"
-},
-{
-    "id": 21,
-    "name": "Psycho",
-    "yearReleased": "1960",
-    "language": "English",
-    "director": " Alfred Hitchcock"
-},
-{
-    "id": 21,
-    "name": "X",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "Ti West"
-},
-{
-    "id": 22,
-    "name": "Annabelle",
-    "yearReleased": "2014",
-    "language": "English",
-    "director": " John R. Leonetti"
-},
-{
-    "id": 23,
-    "name": "nightmare of the elm street",
-    "yearReleased": "1984",
-    "language": "English",
-    "director": "Wes Craven"
-},
-{
-    "id": 24,
-    "name": "Bhool Bhulaiyaa 2",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "Anees Bazmee"
-},
-{
-    "id": 25,
-    "name": "Bhoot",
-    "yearReleased": "2022",
-    "language": "Hindi",
-    "director": "Bhanu Pratap Singh"
-},
-{
-    "id": 26,
-    "name": "Alien: Covenant",
-    "yearReleased": " 2017",
-    "language": "English",
-    "director": "Ridley Scott"
-},
-{
-    "id": 27,
-    "name": "6-5=2",
-    "yearReleased": "2013",
-    "language": "Kannada",
-    "director": "K S Ashoka"
-},
-{
-    "id": 21,
-    "name": "Dybbuk",
-    "yearReleased": "2021",
-    "language": "Hindi",
-    "director": "Jay Krishnan"
-},
-{
-    "id": 28,
-    "name": "House Of Usher",
-    "yearReleased": "1960",
-    "language": "English",
-    "director": "Roger Corman"
-},
-{
-    "id": 21,
-    "name": "The Unholy",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": "Evan Spiliotopoulos"
-},
-{
-    "id": 23,
-    "name": "The Midnigth club",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "Mike Flannagan"
-},
-{
-    "id": 25,
-    "name": "Bhoot",
-    "yearReleased": "2022",
-    "language": "Hindi",
-    "director": "Bhanu Pratap Singh"
-},
-{
-    "id": 26,
-    "name": "Alien: Covenant",
-    "yearReleased": " 2017",
-    "language": "English",
-    "director": "Ridley Scott"
-},
-{
-    "id": 27,
-    "name": "6-5=2",
-    "yearReleased": "2013",
-    "language": "Kannada",
-    "director": "K S Ashoka"
-},
-{
-    "id": 21,
-    "name": "Dybbuk",
-    "yearReleased": "2021",
-    "language": "Hindi",
-    "director": "Jay Krishnan"
-},
-{
-    "id": 28,
-    "name": "House Of Usher",
-    "yearReleased": "1960",
-    "language": "English",
-    "director": "Roger Corman"
-},
-{
-    "id": 21,
-    "name": "stree",
-    "yearReleased": "2020",
-    "language": "Hindi",
-    "director": "dev deol"
-},
-{
-    "id": 21,
-    "name": "Psycho",
-    "yearReleased": "1960",
-    "language": "English",
-    "director": " Alfred Hitchcock"
-},
-{
-    "id": 24,
-    "name": "Dead Silence",
-    "yearReleased": "2007",
-    "language": "English",
-    "director": "James Wan"
-},
-{
-    "id": 21,
-    "name": "Mahal",
-    "yearReleased": "1949",
-    "language": "Hindi",
-    "director": "Kamal Amrohi"
-},
-{
-    "id": 30,
-    "name": "US",
-    "yearReleased": "2019",
-    "language": "English",
-    "director": "Jordan Peele"
-},
-{
-    "id": 50,
-    "name": "1920",
-    "yearReleased": "2008",
-    "language": "Hindi",
-    "director": "Vikram Bhatt"
-},
-{
-    "id": 21,
-    "name": "Annabelle",
-    "yearReleased": "2014",
-    "language": "English",
-    "director": " John R. Leonetti"
-},
-{
-    "id": 28,
-    "name": "Midsommar",
-    "yearReleased": "2019",
-    "language": "English",
-    "director": " Ari Aster"
-},
-{},
-{
-    "id": 23,
-    "name": "The Midnigth club",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "Mike Flannagan"
-},
-{
-    "id": 29,
-    "name": "Orphan",
-    "yearReleased": "2009",
-    "language": "English",
-    "director": "Jaume Collet-Serra"
-},
-{
-    "id": 21,
-    "name": "The Exorcist",
-    "yearReleased": "1973",
-    "language": "English",
-    "director": "William Friedkin"
-},
-{
-    "id": 22,
-    "name": "Bhool Bhulaiyaa 2",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "Anees Bazmee"
-},
-{},
-{
-    "id": 24,
-    "name": "6-5=2",
-    "yearReleased": "2013",
-    "language": "Kannada",
-    "director": "K S Ashoka"
-},
-{
-    "id": 22,
-    "name": "Arundhati",
-    "yearReleased": "2009",
-    "language": "Telugu",
-    "director": "Kodi Ramakrishna"
-},
-{
-    "id": 25,
-    "name": "Nope",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "Jordan Peele"
-},
-{
-    "id": 32,
-    "name": "Bhool Bhulaiyaa  ",
-    "yearReleased": "2007",
-    "language": "Hindi",
-    "director": "Priyadarshan"
-},
-{
-    "id": 32,
-    "name": "stree",
-    "yearReleased": "2019",
-    "language": "Hindi",
-    "director": "Amar Kaushik"
-},
-{
-    "id": 27,
-    "name": "sinister",
-    "yearReleased": "2012",
-    "language": "english",
-    "director": "scott derrickson"
-},
-{
-    "id": 27,
-    "name": "1920",
-    "yearReleased": "2008",
-    "language": "Hindi",
-    "director": "Vikram Bhatt"
-},
-{
-    "id": 28,
-    "name": "Train to Busan",
-    "yearReleased": " 2016",
-    "language": "korean",
-    "director": "Yeon Sang-ho"
-},
-{
-    "id": 27,
-    "name": "sinister2",
-    "yearReleased": "2015",
-    "language": "english",
-    "director": "scott derrickson"
-},
-{
-    "id": 33,
-    "name": "Tumbad",
-    "yearReleased": "2018",
-    "language": "Hindi",
-    "director": "Rahi Barve"
-},
-{
-    "id": 99,
-    "name": "kalo",
-    "yearReleased": "1960",
-    "language": "hindi",
-    "director": "pata nahi"
-},
-{
-    "id": 27,
-    "name": "Bhootkaal",
-    "yearReleased": "2003",
-    "language": "Hindi",
-    "director": "Ram Gopal Varma"
-},
-{
-    "id": 52,
-    "name": "Alone",
-    "yearReleased": "2015",
-    "language": "Hindi",
-    "director": "Bhushan Patel"
-},
-{
-    "id": 53,
-    "name": "vyanki the Dian",
-    "yearReleased": "2022",
-    "language": "Russian",
-    "director": "Vishal chauhan"
-},
-{
-    "id": 27,
-    "name": "sinister",
-    "yearReleased": "2012",
-    "language": "english",
-    "director": "scott derrickson"
-},
-{
-    "id": 27,
-    "name": "1920",
-    "yearReleased": "2008",
-    "language": "Hindi",
-    "director": "Vikram Bhatt"
-},
-{
-    "id": 28,
-    "name": "Train to Busan",
-    "yearReleased": " 2016",
-    "language": "korean",
-    "director": "Yeon Sang-ho"
-},
-{
-    "id": 27,
-    "name": "sinister2",
-    "yearReleased": "2015",
-    "language": "english",
-    "director": "scott derrickson"
-},
-{
-    "id": 21,
-    "name": "The Nun",
-    "yearReleased": "2018",
-    "language": "English",
-    "director": "Corin Hardy"
-},
-{
-    "id": 33,
-    "name": "Tumbad",
-    "yearReleased": "2018",
-    "language": "Hindi",
-    "director": "Rahi Barve"
-},
-{
-    "id": 99,
-    "name": "kalo",
-    "yearReleased": "1960",
-    "language": "hindi",
-    "director": "pata nahi"
-},
-{
-    "id": 52,
-    "name": "Alone",
-    "yearReleased": "2015",
-    "language": "Hindi",
-    "director": "Bhushan Patel"
-},
-{
-    "id": 53,
-    "name": "vyanki the Dian",
-    "yearReleased": "2022",
-    "language": "Russian",
-    "director": "Vishal chauhan"
-},
-{
-    "id": 54,
-    "name": "shaapit",
-    "yearReleased": "2010",
-    "language": "Hindi",
-    "director": "Vikram Bhatt"
-},
-{
-    "id": 27,
-    "name": "Bhootkaal",
-    "yearReleased": "2003",
-    "language": "Hindi",
-    "director": "Ram Gopal Varma"
-},
-{
-    "id": 21,
-    "name": "Bhool Bhulaiyaa 2",
-    "yearReleased": "2022",
-    "language": "English",
-    "director": "TZach Cregger"
-},
-{
-    "id": 20,
-    "name": "Wrong Turn",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": "Mike P. Nelson"
-},
-{
-    "id": 55,
-    "name": "Malignant",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": "James Wan"
-},
-{
-    "id": 24,
-    "name": "IT",
-    "yearReleased": "2017",
-    "language": "English",
-    "director": "Andrés Muschietti"
-},
-{
-    "id": 26,
-    "name": "Host",
-    "yearReleased": "2020",
-    "language": "English",
-    "director": "Andy dataser"
-},
-{
-    "id": 25,
-    "name": "Bhoot",
-    "yearReleased": "2022",
-    "language": "Hindi",
-    "director": "Bhanu Pratap Singh"
-},
-{
-    "id": 21,
-    "name": "Anabella",
-    "yearReleased": "2017",
-    "language": "English",
-    "director": "John R. Leonetti"
-},
-{
-    "id": 27,
-    "name": "sinister2",
-    "yearReleased": "2015",
-    "language": "english",
-    "director": "scott derrickson"
-},
-{
-    "id": 33,
-    "name": "Tumbad",
-    "yearReleased": "2018",
-    "language": "Hindi",
-    "director": "Rahi Barve"
-},
-{
-    "id": 99,
-    "name": "kalo",
-    "yearReleased": "1960",
-    "language": "hindi",
-    "director": "pata nahi"
-},
-{
-    "id": 27,
-    "name": "Bhootkaal",
-    "yearReleased": "2003",
-    "language": "Hindi",
-    "director": "Ram Gopal Varma"
-},
-{
-    "id": 52,
-    "name": "Alone",
-    "yearReleased": "2015",
-    "language": "Hindi",
-    "director": "Bhushan Patel"
-},
-{
-    "id": 53,
-    "name": "vyanki the Dian",
-    "yearReleased": "2022",
-    "language": "Russian",
-    "director": "Vishal chauhan"
-},
-{
-    "id": 56,
-    "name": "Conjuring",
-    "yearReleased": "2013",
-    "language": "English",
-    "director": "James Wan"
-},
-{
-    "id": 29,
-    "name": "Hereditary",
-    "yearReleased": "2018",
-    "language": "English",
-    "director": "Ari Aster"
-},
-{
-    "id": 22,
-    "name": "Roohi",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": "Hardik Mehta"
-},
-{
-    "id": 23,
-    "name": "Stree",
-    "yearReleased": "2018",
-    "language": "English",
-    "director": "Amar Kaushik"
-},
-{
-    "id": 26,
-    "name": "Host",
-    "yearReleased": "2020",
-    "language": "English",
-    "director": "Andy dataser"
-},
-{
-    "id": 7008,
-    "name": "Handjob Cabin",
-    "yearReleased": "2015",
-    "language": "English",
-    "director": "Bennet Silverman"
-},
-{
-    "id": 21,
-    "name": " Chhorii",
-    "yearReleased": "2017",
-    "language": "English",
-    "director": "Vishal Furia"
-},
-{
-    "id": 27,
-    "name": "kanchan",
-    "yearReleased": "2013",
-    "language": "Hindi",
-    "director": "ssr"
-},
-{
-    "id": 21,
-    "name": "Host",
-    "yearRealeased": "2020",
-    "language": "English",
-    "director": "Rob Savage"
-},
-{
-    "id": 22,
-    "name": "The Exorcist",
-    "yearReleased": "1973",
-    "language": "English",
-    "director": "William Friedkin"
-},
-{
-    "id": 52,
-    "name": "Alone",
-    "yearReleased": "2015",
-    "language": "Hindi",
-    "director": "Bhushan Patel"
-},
-{
-    "id": 53,
-    "name": "vyanki the Dian",
-    "yearReleased": "2022",
-    "language": "Russian",
-    "director": "Vishal chauhan"
-},
-{
-    "id": 54,
-    "name": "The Woman in Black",
-    "yearReleased": "2012",
-    "language": "English",
-    "director": "James Watkins"
-},
-{
-    "id": 55,
-    "name": "Innocent Curse",
-    "yearReleased": "2017",
-    "language": "japanese",
-    "director": "Takashi Shimizu"
-},{
-  "id": 56,
-  "name": "Lights Out ",
-  "yearReleased": "2016",
-  "language": "English",
-  "director": "David F. Sandberg"
-},
-
-{
-  "id": 57,
-  "name": "Aftermath",
-  "yearReleased": "2021",
-  "language": "English",
-  "director": " Peter Winther"
-},
-{
-    "id": 52,
-    "name": "Alone",
-    "yearReleased": "2015",
-    "language": "Hindi",
-    "director": "Bhushan Patel"
-},
-{
-    "id": 53,
-    "name": "vyanki the Dian",
-    "yearReleased": "2022",
-    "language": "Russian",
-    "director": "Vishal chauhan"
-},
-{
-    "id": 54,
-    "name": "The Woman in Black",
-    "yearReleased": "2012",
-    "language": "English",
-    "director": "Corin Hardy"
-},
-{
-    "id": 21,
-    "name": "stree",
-    "yearReleased": "2021",
-    "language": "Hindi",
-    "director": "BANSALI"
-},
-{
-    "id": 21,
-    "name": "The Shining",
-    "yearReleased": "1980",
-    "language": "English",
-    "director": "Stanley Kubrick"
-},
-{
-    "id": 52,
-    "name": "Alone",
-    "yearReleased": "2015",
-    "language": "Hindi",
-    "director": "Bhushan Patel"
-},
-{
-    "id": 53,
-    "name": "vyanki the Dian",
-    "yearReleased": "2022",
-    "language": "Russian",
-    "director": "Vishal chauhan"
-},
-{
-    "id": 54,
-    "name": "The Woman in Black",
-    "yearReleased": "2012",
-    "language": "English",
-    "director": "James Watkins"
-},
-{
-    "id": 52,
-    "name": "Alone",
-    "yearReleased": "2015",
-    "language": "Hindi",
-    "director": "Bhushan Patel"
-},
-{
-    "id": 53,
-    "name": "vyanki the Dian",
-    "yearReleased": "2022",
-    "language": "Russian",
-    "director": "Vishal chauhan"
-},
-{
-    "id": 54,
-    "name": "The Woman in Black",
-    "yearReleased": "2012",
-    "language": "English",
-    "director": "James Watkins"
-},
-{
-    "id": 55,
-    "name": "Innocent Curse",
-    "yearReleased": "2017",
-    "language": "japanese",
-    "director": "Takashi Shimizu"
-},
-{
-    "id": 56,
-    "name": "Lights Out ",
-    "yearReleased": "2016",
-    "language": "English",
-    "director": "David F. Sandberg"
-},
-{
-    "id": 57,
-    "name": "Alone",
-    "yearReleased": "2015",
-    "language": "English",
-    "director": "Bhushan Patel"
-},
-{
-    "id": 55,
-    "name": "Innocent Curse",
-    "yearReleased": "2017",
-    "language": "japanese",
-    "director": "Takashi Shimizu"
-},
-{
-    "id": 56,
-    "name": "Old",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": "M. Night Shyamalan"
-},
-{
-    "id": 55,
-    "name": "Innocent Curse",
-    "yearReleased": "2017",
-    "language": "japanese",
-    "director": "Takashi Shimizu"
-},
-{
-    "id": 56,
-    "name": "Lights Out ",
-    "yearReleased": "2016",
-    "language": "English",
-    "director": "David F. Sandberg"
-},
-{
-    "id": 20,
-    "name": "Chhorii",
-    "yearReleased": "2021",
-    "language": "hindi",
-    "director": "Vishal Furia"
-},
-{
-    "id": 21,
-    "name": "Veronica",
-    "yearReleased": "2017",
-    "language": "English",
-    "director": "Paco Plaza"
-},
-{
-    "id": 21,
-    "name": "6-5=2",
-    "yearReleased": "2014",
-    "language": "HINDI",
-    "director": "Bharat Jain"
-},
-{
-    "id": 22,
-    "name": "brahmastra",
-    "yearReleased": "2022",
-    "language": "HINDI",
-    "director": "Ayan Mukerji"
-},
-{
-    "id": 21,
-    "name": "IT'S ALIVE! ",
-    "yearReleased": "1974",
-    "language": "English",
-    "director": "Larry Cohen"
-},
-{
-    "id": 28,
-    "name": "The Grudge",
-    "yearReleased": "2004",
-    "language": "Japanese",
-    "director": "Takashi Shimizu"
-},
-{
-    "id": 21,
-    "name": "Haunted – 3D",
-    "yearReleased": "2011",
-    "language": "Hindi",
-    "director": "Vikram Bhatt"
-},
-{
-    "id": 52,
-    "name": "Alone",
-    "yearReleased": "2015",
-    "language": "Hindi",
-    "director": "Bhushan Patel"
-},
-{
-    "id": 53,
-    "name": "vyanki the Dian",
-    "yearReleased": "2022",
-    "language": "Russian",
-    "director": "Vishal chauhan"
-},
-{
-    "id": 54,
-    "name": "The Woman in Black",
-    "yearReleased": "2012",
-    "language": "English",
-    "director": "James Watkins"
-},
-{
-    "id": 55,
-    "name": "Innocent Curse",
-    "yearReleased": "2017",
-    "language": "japanese",
-    "director": "Takashi Shimizu"
-},
-{
-    "id": 79,
-    "name": "The Ring",
-    "yearReleased": "2003",
-    "language": "English",
-    "director": "Gore Verbinski"
-},
-{
-    "id": 22,
-    "name": "The Conjuring 2",
-    "yearReleased": "2016",
-    "language": "English",
-    "director": "James Wan"
-},
-{
-    "id": 23,
-    "name": "Resident Evil",
-    "yearReleased": "2002",
-    "language": "English",
-    "director": "Paul W.S. Anderson"
-},
-{
-    "id": 21,
-    "name": "The Exorcist",
-    "yearReleased": "1973",
-    "language": "English",
-    "director": "John boorman"
-},
-{
-    "id": 29,
-    "name": "The Conjuring",
-    "yearReleased": "2013",
-    "language": "English",
-    "director": "James Wan"
-},
-{
-    "id": 23,
-    "name": "IT",
-    "yearReleased": "2017",
-    "language": "English",
-    "director": "Andy Muschietti"
-},
-{
-    "id": 24,
-    "name": "Get Out",
-    "yearReleased": "2017",
-    "language": "English",
-    "director": "Jordan Peele"
-},
-{
-    "id": 25,
-    "name": "The Exorcism of Emily Rose",
-    "yearReleased": "2005 ",
-    "language": "English",
-    "director": "Scott Derrickson"
-},
-{
-    "id": 26,
-    "name": "The Unholy",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": "Evan Spiliotopoulos"
-},
-  {
-    "id": 333,
-    "name": "Pontypool",
-    "yearReleased": "2008",
-    "language": "English",
-    "director": "Bruce McDonald"
-  },
-  {
-      "id": 25,
-      "name": "The Exorcism of Emily Rose",
-      "yearReleased": "2005 ",
-      "language": "English",
-      "director": "Scott Derrickson"
-  },
-  {
-      "id": 26,
-      "name": "The Unholy",
-      "yearReleased": "2021",
-      "language": "English",
-      "director": "Evan Spiliotopoulos"
-  },
-  {
-      "id": 27,
-      "name": "10 Cloverfield Lane",
-      "yearReleased": "2016",
-      "language": "English",
-      "director": "Dan Trachtenberg"
-  },
-  {
-    "id": 27,
-      "name": "Martyyrs",
-      "yearReleased": "2008",
-      "language": "French",
-      "director": "Pascal Laugier"
-},
-
-  {
-      "id": 55,
-      "name": "Kanchana",
-      "yearReleased": "2017",
-      "language": "hindi",
-      "director": "P.Vas Shivalinga"
-},
-   {
-      "id": 28,
-      "name": "Bhootiya",
-      "yearReleased": "2020",
-      "language": "Hindi",
-      "director": "Vishal Dadlanni"
-
-
-  },
-  {
-    "id": 100,
-    "name": "Wrong Turn",
-    "yearReleased": "2021",
-    "language": "English",
-    "director": "Mike P. Nelson"
-},
-{
-    "id": 102,
-    "name": "Chhorii",
-    "yearReleased": "2021",
-    "language": "hindi",
-    "director": "Vishal Furia"
-},
-
-{
-          "id": 101,
-          "name": "The Exorcist",
-          "yearReleased": "1973",
-          "language": "English",
-          "director": "William Friedkin"
-   },
     {
-          "id": 114,
-          "name": "The Amityville Horror",
-          "yearReleased": "1979",
-          "language": "English",
-          "director": "Stuart Rosenberg"
-   },
-
-      {
-            "id": 201,
-
-          "name": "Avatar",
-
-          "yearReleased": "2009",
-
-          "language": "English",
-
-          "director": "James Cameron"
-
-},
-{
-    "id": 152,
-    "name": "13B: Fear Has a New Address",
-    "yearReleased": "2009",
-    "language": "Hindi",
-    "director": "Vikram Kumar"
-},
-   {
-    "id": 102,
-    "name": "Resident Evil",
-    "yearReleased": "2002",
-    "language": "English",
-    "director": "Paul W.S. Anderson"
-}
-
+        "id": 1,
+        "name": "Host",
+        "yearReleased": "2020",
+        "language": "English",
+        "director": "Andy dataser"
+    },
+    {
+        "id": 2,
+        "name": "Host",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Andy Newber"
+    },
+    {
+        "id": 3,
+        "name": "The Ring",
+        "yearReleased": "2004",
+        "language": "English",
+        "director": "Andy Newsir"
+    },
+    {
+        "id": 4,
+        "name": "Dahmer",
+        "yearReleased": "2002",
+        "language": "English",
+        "director": "David Jacobson"
+    },
+    {
+        "id": 5,
+        "name": "The Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 6,
+        "name": "one missed call",
+        "yearReleased": "2008",
+        "language": "English",
+        "director": "Eric Vallete"
+    },
+    {
+        "id": 7,
+        "name": "The Midnigth club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 8,
+        "name": "Insidious",
+        "yearReleased": "2010",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 9,
+        "name": "Veronica",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "plazo"
+    },
+    {
+        "id": 10,
+        "name": "Lights Out ",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "David F. Sandberg"
+    },
+    {
+        "id": 11,
+        "name": "Veronica",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "paco plazo"
+    },
+    {
+        "id": 12,
+        "name": " The Omen in Devil Town ",
+        "yearReleased": "1993",
+        "language": "English",
+        "director": "Qumin Lee"
+    },
+    {
+        "id": 13,
+        "name": "Bhootkaal",
+        "yearReleased": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 14,
+        "name": " 6 and 1 (In the Mind)",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": "Sudhanshu Saria"
+    },
+    {
+        "id": 15,
+        "name": "Faz-me Companhia",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": "João Pedro Rodrigues"
+    },
+    {
+        "id": 16,
+        "name": "The Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 17,
+        "name": "Paranormal Activity",
+        "yearReleased": "2007",
+        "language": "English",
+        "director": "Oren Peli"
+    },
+    {
+        "id": 18,
+        "name": "Paranormal Activity 2",
+        "yearReleased": "2010",
+        "language": "English",
+        "director": "Tod Williams"
+    },
+    {
+        "id": 19,
+        "name": "Paranormal Activity 3",
+        "yearReleased": "2011",
+        "language": "English",
+        "director": "Henry joost,Ariel Schulman"
+    },
+    {
+        "id": 20,
+        "name": "Paranormal Activity 4",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "Henry joost,Ariel Schulman"
+    },
+    {
+        "id": 20,
+        "name": "Kanchana",
+        "yearReleased": "2016",
+        "language": "Tamil",
+        "director": "Indian Insan"
+    },
+    {
+        "id": 22,
+        "name": "X",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Ti West"
+    },
+    {
+        "id": 23,
+        "name": " Barbarian",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "TZach Cregger"
+    },
+    {
+        "id": 21,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "William Friedkin"
+    },
+    {
+        "id": 20,
+        "name": "Wrong Turn",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 25,
+        "name": "Wrong Turn",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 26,
+        "name": "Videodrome",
+        "yearReleased": "1983",
+        "language": "English",
+        "director": " David Cronenberg"
+    },
+    {
+        "id": 27,
+        "name": " Horror Story",
+        "yearReleased": "2013",
+        "language": "Hindi",
+        "director": "Ayush Raina"
+    },
+    {
+        "id": 28,
+        "name": "The Exorcist",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Andy Newber"
+    },
+    {
+        "id": 29,
+        "name": "The Weird Man",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 30,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 31,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 21,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 32,
+        "name": "X",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Ti West"
+    },
+    {
+        "id": 33,
+        "name": "Annabelle",
+        "yearReleased": "2014",
+        "language": "English",
+        "director": " John R. Leonetti"
+    },
+    {
+        "id": 34,
+        "name": "nightmare of the elm street",
+        "yearReleased": "1984",
+        "language": "English",
+        "director": "Wes Craven"
+    },
+    {
+        "id": 35,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Anees Bazmee"
+    },
+    {
+        "id": 36,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 37,
+        "name": "Alien: Covenant",
+        "yearReleased": " 2017",
+        "language": "English",
+        "director": "Ridley Scott"
+    },
+    {
+        "id": 27,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 21,
+        "name": "Dybbuk",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "Jay Krishnan"
+    },
+    {
+        "id": 28,
+        "name": "House Of Usher",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": "Roger Corman"
+    },
+    {
+        "id": 21,
+        "name": "The Unholy",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Evan Spiliotopoulos"
+    },
+    {
+        "id": 23,
+        "name": "The Midnigth club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 21,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 21,
+        "name": "X",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Ti West"
+    },
+    {
+        "id": 22,
+        "name": "Annabelle",
+        "yearReleased": "2014",
+        "language": "English",
+        "director": " John R. Leonetti"
+    },
+    {
+        "id": 23,
+        "name": "nightmare of the elm street",
+        "yearReleased": "1984",
+        "language": "English",
+        "director": "Wes Craven"
+    },
+    {
+        "id": 24,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Anees Bazmee"
+    },
+    {
+        "id": 25,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 26,
+        "name": "Alien: Covenant",
+        "yearReleased": " 2017",
+        "language": "English",
+        "director": "Ridley Scott"
+    },
+    {
+        "id": 27,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 21,
+        "name": "Dybbuk",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "Jay Krishnan"
+    },
+    {
+        "id": 28,
+        "name": "House Of Usher",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": "Roger Corman"
+    },
+    {
+        "id": 21,
+        "name": "The Unholy",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Evan Spiliotopoulos"
+    },
+    {
+        "id": 23,
+        "name": "The Midnigth club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 25,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 26,
+        "name": "Alien: Covenant",
+        "yearReleased": " 2017",
+        "language": "English",
+        "director": "Ridley Scott"
+    },
+    {
+        "id": 27,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 21,
+        "name": "Dybbuk",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "Jay Krishnan"
+    },
+    {
+        "id": 28,
+        "name": "House Of Usher",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": "Roger Corman"
+    },
+    {
+        "id": 21,
+        "name": "stree",
+        "yearReleased": "2020",
+        "language": "Hindi",
+        "director": "dev deol"
+    },
+    {
+        "id": 21,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 24,
+        "name": "Dead Silence",
+        "yearReleased": "2007",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 21,
+        "name": "Mahal",
+        "yearReleased": "1949",
+        "language": "Hindi",
+        "director": "Kamal Amrohi"
+    },
+    {
+        "id": 30,
+        "name": "US",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": "Jordan Peele"
+    },
+    {
+        "id": 50,
+        "name": "1920",
+        "yearReleased": "2008",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 21,
+        "name": "Annabelle",
+        "yearReleased": "2014",
+        "language": "English",
+        "director": " John R. Leonetti"
+    },
+    {
+        "id": 28,
+        "name": "Midsommar",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": " Ari Aster"
+    },
+    {},
+    {
+        "id": 23,
+        "name": "The Midnigth club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 29,
+        "name": "Orphan",
+        "yearReleased": "2009",
+        "language": "English",
+        "director": "Jaume Collet-Serra"
+    },
+    {
+        "id": 21,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "William Friedkin"
+    },
+    {
+        "id": 22,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Anees Bazmee"
+    },
+    {},
+    {
+        "id": 24,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 22,
+        "name": "Arundhati",
+        "yearReleased": "2009",
+        "language": "Telugu",
+        "director": "Kodi Ramakrishna"
+    },
+    {
+        "id": 25,
+        "name": "Nope",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Jordan Peele"
+    },
+    {
+        "id": 32,
+        "name": "Bhool Bhulaiyaa  ",
+        "yearReleased": "2007",
+        "language": "Hindi",
+        "director": "Priyadarshan"
+    },
+    {
+        "id": 32,
+        "name": "stree",
+        "yearReleased": "2019",
+        "language": "Hindi",
+        "director": "Amar Kaushik"
+    },
+    {
+        "id": 27,
+        "name": "sinister",
+        "yearReleased": "2012",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 27,
+        "name": "1920",
+        "yearReleased": "2008",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 28,
+        "name": "Train to Busan",
+        "yearReleased": " 2016",
+        "language": "korean",
+        "director": "Yeon Sang-ho"
+    },
+    {
+        "id": 27,
+        "name": "sinister2",
+        "yearReleased": "2015",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 33,
+        "name": "Tumbad",
+        "yearReleased": "2018",
+        "language": "Hindi",
+        "director": "Rahi Barve"
+    },
+    {
+        "id": 99,
+        "name": "kalo",
+        "yearReleased": "1960",
+        "language": "hindi",
+        "director": "pata nahi"
+    },
+    {
+        "id": 27,
+        "name": "Bhootkaal",
+        "yearReleased": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 27,
+        "name": "sinister",
+        "yearReleased": "2012",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 27,
+        "name": "1920",
+        "yearReleased": "2008",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 28,
+        "name": "Train to Busan",
+        "yearReleased": " 2016",
+        "language": "korean",
+        "director": "Yeon Sang-ho"
+    },
+    {
+        "id": 27,
+        "name": "sinister2",
+        "yearReleased": "2015",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 21,
+        "name": "The Nun",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Corin Hardy"
+    },
+    {
+        "id": 33,
+        "name": "Tumbad",
+        "yearReleased": "2018",
+        "language": "Hindi",
+        "director": "Rahi Barve"
+    },
+    {
+        "id": 99,
+        "name": "kalo",
+        "yearReleased": "1960",
+        "language": "hindi",
+        "director": "pata nahi"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "shaapit",
+        "yearReleased": "2010",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 27,
+        "name": "Bhootkaal",
+        "yearReleased": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 21,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "TZach Cregger"
+    },
+    {
+        "id": 20,
+        "name": "Wrong Turn",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 55,
+        "name": "Malignant",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 24,
+        "name": "IT",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Andrés Muschietti"
+    },
+    {
+        "id": 26,
+        "name": "Host",
+        "yearReleased": "2020",
+        "language": "English",
+        "director": "Andy dataser"
+    },
+    {
+        "id": 25,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 21,
+        "name": "Anabella",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "John R. Leonetti"
+    },
+    {
+        "id": 27,
+        "name": "sinister2",
+        "yearReleased": "2015",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 33,
+        "name": "Tumbad",
+        "yearReleased": "2018",
+        "language": "Hindi",
+        "director": "Rahi Barve"
+    },
+    {
+        "id": 99,
+        "name": "kalo",
+        "yearReleased": "1960",
+        "language": "hindi",
+        "director": "pata nahi"
+    },
+    {
+        "id": 27,
+        "name": "Bhootkaal",
+        "yearReleased": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 56,
+        "name": "Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 29,
+        "name": "Hereditary",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Ari Aster"
+    },
+    {
+        "id": 22,
+        "name": "Roohi",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Hardik Mehta"
+    },
+    {
+        "id": 23,
+        "name": "Stree",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Amar Kaushik"
+    },
+    {
+        "id": 26,
+        "name": "Host",
+        "yearReleased": "2020",
+        "language": "English",
+        "director": "Andy dataser"
+    },
+    {
+        "id": 7008,
+        "name": "Handjob Cabin",
+        "yearReleased": "2015",
+        "language": "English",
+        "director": "Bennet Silverman"
+    },
+    {
+        "id": 21,
+        "name": " Chhorii",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Vishal Furia"
+    },
+    {
+        "id": 27,
+        "name": "kanchan",
+        "yearReleased": "2013",
+        "language": "Hindi",
+        "director": "ssr"
+    },
+    {
+        "id": 21,
+        "name": "Host",
+        "yearRealeased": "2020",
+        "language": "English",
+        "director": "Rob Savage"
+    },
+    {
+        "id": 22,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "William Friedkin"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 56,
+        "name": "Lights Out ",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "David F. Sandberg"
+    },
+    {
+        "id": 57,
+        "name": "Aftermath",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": " Peter Winther"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "Corin Hardy"
+    },
+    {
+        "id": 21,
+        "name": "stree",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "BANSALI"
+    },
+    {
+        "id": 21,
+        "name": "The Shining",
+        "yearReleased": "1980",
+        "language": "English",
+        "director": "Stanley Kubrick"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 56,
+        "name": "Lights Out ",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "David F. Sandberg"
+    },
+    {
+        "id": 57,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "English",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 56,
+        "name": "Old",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "M. Night Shyamalan"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 56,
+        "name": "Lights Out ",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "David F. Sandberg"
+    },
+    {
+        "id": 20,
+        "name": "Chhorii",
+        "yearReleased": "2021",
+        "language": "hindi",
+        "director": "Vishal Furia"
+    },
+    {
+        "id": 21,
+        "name": "Veronica",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Paco Plaza"
+    },
+    {
+        "id": 21,
+        "name": "6-5=2",
+        "yearReleased": "2014",
+        "language": "HINDI",
+        "director": "Bharat Jain"
+    },
+    {
+        "id": 22,
+        "name": "brahmastra",
+        "yearReleased": "2022",
+        "language": "HINDI",
+        "director": "Ayan Mukerji"
+    },
+    {
+        "id": 21,
+        "name": "IT'S ALIVE! ",
+        "yearReleased": "1974",
+        "language": "English",
+        "director": "Larry Cohen"
+    },
+    {
+        "id": 28,
+        "name": "The Grudge",
+        "yearReleased": "2004",
+        "language": "Japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 21,
+        "name": "Haunted – 3D",
+        "yearReleased": "2011",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 79,
+        "name": "The Ring",
+        "yearReleased": "2003",
+        "language": "English",
+        "director": "Gore Verbinski"
+    },
+    {
+        "id": 22,
+        "name": "The Conjuring 2",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 23,
+        "name": "Resident Evil",
+        "yearReleased": "2002",
+        "language": "English",
+        "director": "Paul W.S. Anderson"
+    },
+    {
+        "id": 21,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "John boorman"
+    },
+    {
+        "id": 29,
+        "name": "The Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 23,
+        "name": "IT",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Andy Muschietti"
+    },
+    {
+        "id": 24,
+        "name": "Get Out",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Jordan Peele"
+    },
+    {
+        "id": 1,
+        "name": "Host",
+        "yearReleased": "2020",
+        "language": "English",
+        "director": "Andy dataser"
+    },
+    {
+        "id": 2,
+        "name": "Host",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Andy Newber"
+    },
+    {
+        "id": 3,
+        "name": "The Ring",
+        "yearReleased": "2004",
+        "language": "English",
+        "director": "Andy Newsir"
+    },
+    {
+        "id": 4,
+        "name": "Dahmer",
+        "yearReleased": "2002",
+        "language": "English",
+        "director": "David Jacobson"
+    },
+    {
+        "id": 5,
+        "name": "The Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 6,
+        "name": "one missed call",
+        "yearReleased": "2008",
+        "language": "English",
+        "director": "Eric Vallete"
+    },
+    {
+        "id": 7,
+        "name": "The Midnigth club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 8,
+        "name": "Insidious",
+        "yearReleased": "2010",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 9,
+        "name": "Veronica",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "plazo"
+    },
+    {
+        "id": 10,
+        "name": "Lights Out ",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "David F. Sandberg"
+    },
+    {
+        "id": 11,
+        "name": "Veronica",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "paco plazo"
+    },
+    {
+        "id": 12,
+        "name": " The Omen in Devil Town ",
+        "yearReleased": "1993",
+        "language": "English",
+        "director": "Qumin Lee"
+    },
+    {
+        "id": 13,
+        "name": "Bhootkaal",
+        "yearReleased": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 14,
+        "name": " 6 and 1 (In the Mind)",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": "Sudhanshu Saria"
+    },
+    {
+        "id": 15,
+        "name": "Faz-me Companhia",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": "João Pedro Rodrigues"
+    },
+    {
+        "id": 16,
+        "name": "The Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 17,
+        "name": "Paranormal Activity",
+        "yearReleased": "2007",
+        "language": "English",
+        "director": "Oren Peli"
+    },
+    {
+        "id": 18,
+        "name": "Paranormal Activity 2",
+        "yearReleased": "2010",
+        "language": "English",
+        "director": "Tod Williams"
+    },
+    {
+        "id": 19,
+        "name": "Paranormal Activity 3",
+        "yearReleased": "2011",
+        "language": "English",
+        "director": "Henry joost,Ariel Schulman"
+    },
+    {
+        "id": 20,
+        "name": "Paranormal Activity 4",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "Henry joost,Ariel Schulman"
+    },
+    {
+        "id": 20,
+        "name": "Kanchana",
+        "yearReleased": "2016",
+        "language": "Tamil",
+        "director": "Indian Insan"
+    },
+    {
+        "id": 22,
+        "name": "X",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Ti West"
+    },
+    {
+        "id": 23,
+        "name": " Barbarian",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "TZach Cregger"
+    },
+    {
+        "id": 21,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "William Friedkin"
+    },
+    {
+        "id": 20,
+        "name": "Wrong Turn",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 25,
+        "name": "Wrong Turn",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 26,
+        "name": "Videodrome",
+        "yearReleased": "1983",
+        "language": "English",
+        "director": " David Cronenberg"
+    },
+    {
+        "id": 27,
+        "name": " Horror Story",
+        "yearReleased": "2013",
+        "language": "Hindi",
+        "director": "Ayush Raina"
+    },
+    {
+        "id": 28,
+        "name": "The Exorcist",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Andy Newber"
+    },
+    {
+        "id": 29,
+        "name": "The Weird Man",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 30,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 31,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 21,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 32,
+        "name": "X",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Ti West"
+    },
+    {
+        "id": 33,
+        "name": "Annabelle",
+        "yearReleased": "2014",
+        "language": "English",
+        "director": " John R. Leonetti"
+    },
+    {
+        "id": 34,
+        "name": "nightmare of the elm street",
+        "yearReleased": "1984",
+        "language": "English",
+        "director": "Wes Craven"
+    },
+    {
+        "id": 35,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Anees Bazmee"
+    },
+    {
+        "id": 36,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 37,
+        "name": "Alien: Covenant",
+        "yearReleased": " 2017",
+        "language": "English",
+        "director": "Ridley Scott"
+    },
+    {
+        "id": 27,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 21,
+        "name": "Dybbuk",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "Jay Krishnan"
+    },
+    {
+        "id": 28,
+        "name": "House Of Usher",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": "Roger Corman"
+    },
+    {
+        "id": 21,
+        "name": "The Unholy",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Evan Spiliotopoulos"
+    },
+    {
+        "id": 23,
+        "name": "The Midnigth club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 21,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 21,
+        "name": "X",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Ti West"
+    },
+    {
+        "id": 22,
+        "name": "Annabelle",
+        "yearReleased": "2014",
+        "language": "English",
+        "director": " John R. Leonetti"
+    },
+    {
+        "id": 23,
+        "name": "nightmare of the elm street",
+        "yearReleased": "1984",
+        "language": "English",
+        "director": "Wes Craven"
+    },
+    {
+        "id": 24,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Anees Bazmee"
+    },
+    {
+        "id": 25,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 26,
+        "name": "Alien: Covenant",
+        "yearReleased": " 2017",
+        "language": "English",
+        "director": "Ridley Scott"
+    },
+    {
+        "id": 27,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 21,
+        "name": "Dybbuk",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "Jay Krishnan"
+    },
+    {
+        "id": 28,
+        "name": "House Of Usher",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": "Roger Corman"
+    },
+    {
+        "id": 21,
+        "name": "The Unholy",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Evan Spiliotopoulos"
+    },
+    {
+        "id": 23,
+        "name": "The Midnigth club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 25,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 26,
+        "name": "Alien: Covenant",
+        "yearReleased": " 2017",
+        "language": "English",
+        "director": "Ridley Scott"
+    },
+    {
+        "id": 27,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 21,
+        "name": "Dybbuk",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "Jay Krishnan"
+    },
+    {
+        "id": 28,
+        "name": "House Of Usher",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": "Roger Corman"
+    },
+    {
+        "id": 21,
+        "name": "stree",
+        "yearReleased": "2020",
+        "language": "Hindi",
+        "director": "dev deol"
+    },
+    {
+        "id": 21,
+        "name": "Psycho",
+        "yearReleased": "1960",
+        "language": "English",
+        "director": " Alfred Hitchcock"
+    },
+    {
+        "id": 24,
+        "name": "Dead Silence",
+        "yearReleased": "2007",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 21,
+        "name": "Mahal",
+        "yearReleased": "1949",
+        "language": "Hindi",
+        "director": "Kamal Amrohi"
+    },
+    {
+        "id": 30,
+        "name": "US",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": "Jordan Peele"
+    },
+    {
+        "id": 50,
+        "name": "1920",
+        "yearReleased": "2008",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 21,
+        "name": "Annabelle",
+        "yearReleased": "2014",
+        "language": "English",
+        "director": " John R. Leonetti"
+    },
+    {
+        "id": 28,
+        "name": "Midsommar",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": " Ari Aster"
+    },
+    {},
+    {
+        "id": 23,
+        "name": "The Midnigth club",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Mike Flannagan"
+    },
+    {
+        "id": 29,
+        "name": "Orphan",
+        "yearReleased": "2009",
+        "language": "English",
+        "director": "Jaume Collet-Serra"
+    },
+    {
+        "id": 21,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "William Friedkin"
+    },
+    {
+        "id": 22,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Anees Bazmee"
+    },
+    {},
+    {
+        "id": 24,
+        "name": "6-5=2",
+        "yearReleased": "2013",
+        "language": "Kannada",
+        "director": "K S Ashoka"
+    },
+    {
+        "id": 22,
+        "name": "Arundhati",
+        "yearReleased": "2009",
+        "language": "Telugu",
+        "director": "Kodi Ramakrishna"
+    },
+    {
+        "id": 25,
+        "name": "Nope",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "Jordan Peele"
+    },
+    {
+        "id": 32,
+        "name": "Bhool Bhulaiyaa  ",
+        "yearReleased": "2007",
+        "language": "Hindi",
+        "director": "Priyadarshan"
+    },
+    {
+        "id": 32,
+        "name": "stree",
+        "yearReleased": "2019",
+        "language": "Hindi",
+        "director": "Amar Kaushik"
+    },
+    {
+        "id": 27,
+        "name": "sinister",
+        "yearReleased": "2012",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 27,
+        "name": "1920",
+        "yearReleased": "2008",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 28,
+        "name": "Train to Busan",
+        "yearReleased": " 2016",
+        "language": "korean",
+        "director": "Yeon Sang-ho"
+    },
+    {
+        "id": 27,
+        "name": "sinister2",
+        "yearReleased": "2015",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 33,
+        "name": "Tumbad",
+        "yearReleased": "2018",
+        "language": "Hindi",
+        "director": "Rahi Barve"
+    },
+    {
+        "id": 99,
+        "name": "kalo",
+        "yearReleased": "1960",
+        "language": "hindi",
+        "director": "pata nahi"
+    },
+    {
+        "id": 27,
+        "name": "Bhootkaal",
+        "yearReleased": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 27,
+        "name": "sinister",
+        "yearReleased": "2012",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 27,
+        "name": "1920",
+        "yearReleased": "2008",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 28,
+        "name": "Train to Busan",
+        "yearReleased": " 2016",
+        "language": "korean",
+        "director": "Yeon Sang-ho"
+    },
+    {
+        "id": 27,
+        "name": "sinister2",
+        "yearReleased": "2015",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 21,
+        "name": "The Nun",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Corin Hardy"
+    },
+    {
+        "id": 33,
+        "name": "Tumbad",
+        "yearReleased": "2018",
+        "language": "Hindi",
+        "director": "Rahi Barve"
+    },
+    {
+        "id": 99,
+        "name": "kalo",
+        "yearReleased": "1960",
+        "language": "hindi",
+        "director": "pata nahi"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "shaapit",
+        "yearReleased": "2010",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 27,
+        "name": "Bhootkaal",
+        "yearReleased": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 21,
+        "name": "Bhool Bhulaiyaa 2",
+        "yearReleased": "2022",
+        "language": "English",
+        "director": "TZach Cregger"
+    },
+    {
+        "id": 20,
+        "name": "Wrong Turn",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 55,
+        "name": "Malignant",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 24,
+        "name": "IT",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Andrés Muschietti"
+    },
+    {
+        "id": 26,
+        "name": "Host",
+        "yearReleased": "2020",
+        "language": "English",
+        "director": "Andy dataser"
+    },
+    {
+        "id": 25,
+        "name": "Bhoot",
+        "yearReleased": "2022",
+        "language": "Hindi",
+        "director": "Bhanu Pratap Singh"
+    },
+    {
+        "id": 21,
+        "name": "Anabella",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "John R. Leonetti"
+    },
+    {
+        "id": 27,
+        "name": "sinister2",
+        "yearReleased": "2015",
+        "language": "english",
+        "director": "scott derrickson"
+    },
+    {
+        "id": 33,
+        "name": "Tumbad",
+        "yearReleased": "2018",
+        "language": "Hindi",
+        "director": "Rahi Barve"
+    },
+    {
+        "id": 99,
+        "name": "kalo",
+        "yearReleased": "1960",
+        "language": "hindi",
+        "director": "pata nahi"
+    },
+    {
+        "id": 27,
+        "name": "Bhootkaal",
+        "yearRelea  sed": "2003",
+        "language": "Hindi",
+        "director": "Ram Gopal Varma"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 56,
+        "name": "Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 29,
+        "name": "Hereditary",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Ari Aster"
+    },
+    {
+        "id": 22,
+        "name": "Roohi",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Hardik Mehta"
+    },
+    {
+        "id": 23,
+        "name": "Stree",
+        "yearReleased": "2018",
+        "language": "English",
+        "director": "Amar Kaushik"
+    },
+    {
+        "id": 26,
+        "name": "Host",
+        "yearReleased": "2020",
+        "language": "English",
+        "director": "Andy dataser"
+    },
+    {
+        "id": 7008,
+        "name": "Handjob Cabin",
+        "yearReleased": "2015",
+        "language": "English",
+        "director": "Bennet Silverman"
+    },
+    {
+        "id": 21,
+        "name": " Chhorii",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Vishal Furia"
+    },
+    {
+        "id": 27,
+        "name": "kanchan",
+        "yearReleased": "2013",
+        "language": "Hindi",
+        "director": "ssr"
+    },
+    {
+        "id": 21,
+        "name": "Host",
+        "yearRealeased": "2020",
+        "language": "English",
+        "director": "Rob Savage"
+    },
+    {
+        "id": 22,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "William Friedkin"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 56,
+        "name": "Lights Out ",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "David F. Sandberg"
+    },
+    {
+        "id": 57,
+        "name": "Aftermath",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": " Peter Winther"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "Corin Hardy"
+    },
+    {
+        "id": 21,
+        "name": "stree",
+        "yearReleased": "2021",
+        "language": "Hindi",
+        "director": "BANSALI"
+    },
+    {
+        "id": 21,
+        "name": "The Shining",
+        "yearReleased": "1980",
+        "language": "English",
+        "director": "Stanley Kubrick"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 56,
+        "name": "Lights Out ",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "David F. Sandberg"
+    },
+    {
+        "id": 57,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "English",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 56,
+        "name": "Old",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "M. Night Shyamalan"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 56,
+        "name": "Lights Out ",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "David F. Sandberg"
+    },
+    {
+        "id": 20,
+        "name": "Chhorii",
+        "yearReleased": "2021",
+        "language": "hindi",
+        "director": "Vishal Furia"
+    },
+    {
+        "id": 21,
+        "name": "Veronica",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Paco Plaza"
+    },
+    {
+        "id": 21,
+        "name": "6-5=2",
+        "yearReleased": "2014",
+        "language": "HINDI",
+        "director": "Bharat Jain"
+    },
+    {
+        "id": 22,
+        "name": "brahmastra",
+        "yearReleased": "2022",
+        "language": "HINDI",
+        "director": "Ayan Mukerji"
+    },
+    {
+        "id": 21,
+        "name": "IT'S ALIVE! ",
+        "yearReleased": "1974",
+        "language": "English",
+        "director": "Larry Cohen"
+    },
+    {
+        "id": 28,
+        "name": "The Grudge",
+        "yearReleased": "2004",
+        "language": "Japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 21,
+        "name": "Haunted – 3D",
+        "yearReleased": "2011",
+        "language": "Hindi",
+        "director": "Vikram Bhatt"
+    },
+    {
+        "id": 52,
+        "name": "Alone",
+        "yearReleased": "2015",
+        "language": "Hindi",
+        "director": "Bhushan Patel"
+    },
+    {
+        "id": 53,
+        "name": "vyanki the Dian",
+        "yearReleased": "2022",
+        "language": "Russian",
+        "director": "Vishal chauhan"
+    },
+    {
+        "id": 54,
+        "name": "The Woman in Black",
+        "yearReleased": "2012",
+        "language": "English",
+        "director": "James Watkins"
+    },
+    {
+        "id": 55,
+        "name": "Innocent Curse",
+        "yearReleased": "2017",
+        "language": "japanese",
+        "director": "Takashi Shimizu"
+    },
+    {
+        "id": 79,
+        "name": "The Ring",
+        "yearReleased": "2003",
+        "language": "English",
+        "director": "Gore Verbinski"
+    },
+    {
+        "id": 22,
+        "name": "The Conjuring 2",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 23,
+        "name": "Resident Evil",
+        "yearReleased": "2002",
+        "language": "English",
+        "director": "Paul W.S. Anderson"
+    },
+    {
+        "id": 21,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "John boorman"
+    },
+    {
+        "id": 29,
+        "name": "The Conjuring",
+        "yearReleased": "2013",
+        "language": "English",
+        "director": "James Wan"
+    },
+    {
+        "id": 23,
+        "name": "IT",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Andy Muschietti"
+    },
+    {
+        "id": 24,
+        "name": "Get Out",
+        "yearReleased": "2017",
+        "language": "English",
+        "director": "Jordan Peele"
+    },
+    {
+        "id": 25,
+        "name": "The Exorcism of Emily Rose",
+        "yearReleased": "2005 ",
+        "language": "English",
+        "director": "Scott Derrickson"
+    },
+    {
+        "id": 26,
+        "name": "The Unholy",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Evan Spiliotopoulos"
+    },
+    {
+        "id": 333,
+        "name": "Pontypool",
+        "yearReleased": "2008",
+        "language": "English",
+        "director": "Bruce McDonald"
+    },
+    {
+        "id": 25,
+        "name": "The Exorcism of Emily Rose",
+        "yearReleased": "2005 ",
+        "language": "English",
+        "director": "Scott Derrickson"
+    },
+    {
+        "id": 26,
+        "name": "The Unholy",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Evan Spiliotopoulos"
+    },
+    {
+        "id": 27,
+        "name": "10 Cloverfield Lane",
+        "yearReleased": "2016",
+        "language": "English",
+        "director": "Dan Trachtenberg"
+    },
+    {
+        "id": 27,
+        "name": "Martyyrs",
+        "yearReleased": "2008",
+        "language": "French",
+        "director": "Pascal Laugier"
+    },
+    {
+        "id": 55,
+        "name": "Kanchana",
+        "yearReleased": "2017",
+        "language": "hindi",
+        "director": "P.Vas Shivalinga"
+    },
+    {
+        "id": 28,
+        "name": "Bhootiya",
+        "yearReleased": "2020",
+        "language": "Hindi",
+        "director": "Vishal Dadlanni"
+    },
+    {
+        "id": 100,
+        "name": "Wrong Turn",
+        "yearReleased": "2021",
+        "language": "English",
+        "director": "Mike P. Nelson"
+    },
+    {
+        "id": 102,
+        "name": "Chhorii",
+        "yearReleased": "2021",
+        "language": "hindi",
+        "director": "Vishal Furia"
+    },
+    {
+        "id": 101,
+        "name": "The Exorcist",
+        "yearReleased": "1973",
+        "language": "English",
+        "director": "William Friedkin"
+    },
+    {
+        "id": 114,
+        "name": "The Amityville Horror",
+        "yearReleased": "1979",
+        "language": "English",
+        "director": "Stuart Rosenberg"
+    },
+    {
+        "id": 201,
+        "name": "Avatar",
+        "yearReleased": "2009",
+        "language": "English",
+        "director": "James Cameron"
+    },
+    {
+        "id": 152,
+        "name": "13B: Fear Has a New Address",
+        "yearReleased": "2009",
+        "language": "Hindi",
+        "director": "Vikram Kumar"
+    },
+    {
+        "id": 673,
+        "name": "A Serbian Film",
+        "yearReleased": "2010",
+        "language": "Serbian, English, Swedish",
+        "director": "Srdjan Spasojevic"
+    },
+    {
+        "id": 674,
+        "name": "8: A South African Horror Story",
+        "yearReleased": "2019",
+        "language": "English",
+        "director": "Harold Holscher"
+    }
 ]

--- a/data.json
+++ b/data.json
@@ -4661,5 +4661,12 @@
     "yearReleased": "2019",
     "language": "English",
     "director": "Harold Holscher"
+  },
+  {
+    "id": "016c1315-6a1c-4e1c-b352-461f9ccde014",
+    "name": "Doctor Sleep",
+    "yearReleased": "2019",
+    "director": "Mike Flanagan",
+    "language": "English"
   }
 ]

--- a/index.js
+++ b/index.js
@@ -1,31 +1,26 @@
-const express = require('express');
-const app = express();
-const PORT = 5000;
+const express = require('express')
+const app = express()
+const PORT = 5000
 
-const data = require('data.json');
-app.use(express.json());
+const data = require('./data.json')
+app.use(express.json())
 
-app.get('/', (req,res)=>{
-    return res.json(
-        {
-            message: "Horror Movies API"
-        }
-    )
-});
+app.get('/', (req, res) => {
+  return res.json({
+    message: 'Horror Movies API',
+    totalMovies: data.length,
+  })
+})
 
 //any random
-app.get('/random', (req,res)=>{
-    const numberOfElements = data.length;
-    const randomNumber = parseInt(Math.random()*numberOfElements);
-    return res.json(data[randomNumber])
-});
+app.get('/random', (req, res) => {
+  const numberOfElements = data.length
+  const randomNumber = parseInt(Math.random() * numberOfElements)
+  return res.json(data[randomNumber])
+})
 
-//list
+app.listen(PORT, () => {
+  console.info('Server has stated', 'http://localhost:' + PORT)
+})
 
-
-// app.listen(5000, ()=>{
-//     console.log("Server has stated");
-// });
-
-module.exports = app;
-
+module.exports = app

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 const express = require('express')
 const app = express()
+const data = require('./data.json')
+
 const PORT = 5000
 
-const data = require('./data.json')
 app.use(express.json())
 
 app.get('/', (req, res) => {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "start": "node ./index.js",
+    "add-movie": "node ./src/addMovie.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "description": "",

--- a/package.json
+++ b/package.json
@@ -1,27 +1,15 @@
 {
-  "name": "first_micro",
-  "version": "1.0.0",
+  "name": "horror-movies-api",
+  "version": "3.1.2",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  {
-  "name": "raaz reoot",
-  "version": "1.0.0",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.1"
   },
-   "name": "third_macro",
-  "version": "3.1.2",
-  "main": "index.js",
   "scripts": {
+    "start": "node ./index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "description": "",

--- a/src/addMovie.js
+++ b/src/addMovie.js
@@ -2,6 +2,8 @@
 
 var readline = require('readline')
 const { randomUUID } = require('crypto')
+const fs = require('fs')
+
 const movies = require('../data.json')
 
 var rl = readline.createInterface({
@@ -9,12 +11,23 @@ var rl = readline.createInterface({
   output: process.stdout,
 })
 
-rl.question('1/4: Enter the movie name: ', function (name) {
+console.log('#### 🧟🔪🩸💀 ####')
+console.log('Hello! ')
+console.log('Thank you for helping us build a database of HORROR movies.')
+console.log(
+  'Use this tool to enter the Name, Year, Director and Language of the film.'
+)
+console.log('#### 🧟🔪🩸💀 ####')
+
+rl.question('1/4: Movie name? ', function (name) {
   const lowercaseName = name.toLowerCase()
   const duplicates = movies.filter((item) => {
     return lowercaseName === `${item.name}`.toLowerCase()
   })
 
+  // Warn user if there are duplicates.
+  // Could be a remake of an old movie from a different year,
+  // So don't close yet.
   if (duplicates.length > 0) {
     console.warn('Warning: someone may already have submitted ' + name, {
       duplicates,
@@ -29,6 +42,7 @@ rl.question('1/4: Enter the movie name: ', function (name) {
       return yearReleasedStr === itemYearStr
     })
 
+    // Don't let the user add a movie with the same name in the same year.
     if (duplicatesInSameYear.length > 0) {
       console.error('Sorry, this movie has been added already. Try again. ')
       console.error(duplicatesInSameYear[0])
@@ -40,10 +54,27 @@ rl.question('1/4: Enter the movie name: ', function (name) {
       console.log(director)
 
       rl.question('4/4: Language? ', function (language) {
-        console.log({ id: randomUUID(), movieName, year, director, language })
-        // Add move it data.json.
+        const newMovie = {
+          id: randomUUID(),
+          name,
+          // year should be string, for consistency.
+          yearReleased: `${yearReleased}`,
+          director,
+          language,
+        }
+        const newMovies = JSON.stringify([...movies, newMovie], null, 2)
 
-        rl.close()
+        fs.writeFile('./data.json', newMovies, (err) => {
+          if (err) {
+            console.error('We tried, but the file could not be updatred')
+            console.error(e?.message)
+          } else {
+            console.info(`Thanks! ${name} was added to the database.`)
+            console.info(newMovie)
+            console.error('Now please create a PR to merge your contribution!.')
+          }
+          rl.close()
+        })
       })
     })
   })

--- a/src/addMovie.js
+++ b/src/addMovie.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+var readline = require('readline')
+const { randomUUID } = require('crypto')
+const movies = require('../data.json')
+
+var rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+})
+
+rl.question('1/4: Enter the movie name: ', function (name) {
+  const lowercaseName = name.toLowerCase()
+  const duplicates = movies.filter((item) => {
+    return lowercaseName === `${item.name}`.toLowerCase()
+  })
+
+  if (duplicates.length > 0) {
+    console.warn('Warning: someone may already have submitted ' + name, {
+      duplicates,
+    })
+  }
+
+  rl.question('2/4: Year released? (eg. 2022): ', function (yearReleased) {
+    console.log(yearReleased)
+    const duplicatesInSameYear = duplicates.filter((item) => {
+      const yearReleasedStr = `${item.yearRealeased}`
+      const itemYearStr = `${item.yearRealeased}`
+      return yearReleasedStr === itemYearStr
+    })
+
+    if (duplicatesInSameYear.length > 0) {
+      console.error('Sorry, this movie has been added already. Try again. ')
+      console.error(duplicatesInSameYear[0])
+      rl.close()
+      return
+    }
+
+    rl.question("3/4: Who's the director? ", function (director) {
+      console.log(director)
+
+      rl.question('4/4: Language? ', function (language) {
+        console.log({ id: randomUUID(), movieName, year, director, language })
+        // Add move it data.json.
+
+        rl.close()
+      })
+    })
+  })
+})


### PR DESCRIPTION
# What problem is it solving:
- Movie ID's can be duplicated, due to human error.
- Users could enter movies with incorrect field names.
- data.json file loses formatting.
- Users add duplicate films (Same name and year released).

# How it works:
Users can use the CLI tool to add a film:
`npm run add-movie` or `yarn add-movie`
Validation is added to check for existing movies that have the same name and year released.

# Demo:

https://user-images.githubusercontent.com/11704483/193445543-8c97b82b-c6e0-4a00-a5bc-19e7a6811971.mov

